### PR TITLE
Feature/account authentication / 기능 수정 및 test 코드 생성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,12 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     java
     id("org.springframework.boot") version "3.5.3"
     id("io.spring.dependency-management") version "1.1.7"
+    kotlin("jvm") version "1.9.22"
+    kotlin("plugin.spring") version "1.9.22"
 }
 
 group = "com.example"
@@ -10,6 +15,8 @@ version = "0.0.1-SNAPSHOT"
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 }
 
@@ -64,11 +71,42 @@ dependencies {
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 
+    //test
+    testImplementation("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation(platform("org.junit:junit-bom:5.10.0"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("io.mockk:mockk:1.13.12")
+    testImplementation("io.kotest:kotest-runner-junit5:5.8.1")
+    testImplementation("io.kotest:kotest-assertions-core:5.8.1")
+    testImplementation("io.kotest:kotest-framework-engine:5.8.1")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
 }
 
-tasks.test {
+kotlin{
+    sourceSets {
+        test {
+            kotlin.srcDirs(listOf("src/test/kotlin"))
+        }
+    }
+}
+
+tasks.withType<Test> {
     useJUnitPlatform()
+    jvmArgs("--enable-preview")
+}
+
+tasks.withType<KotlinCompile> {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_21
+    }
+}
+
+tasks.withType<JavaCompile> {
+    options.compilerArgs.addAll(listOf(
+        "--enable-preview",
+        "-Amapstruct.defaultComponentModel=spring",
+    ))
+}
+
+tasks.named<JavaExec>("bootRun") {
+    jvmArgs("--enable-preview")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
     testImplementation("io.kotest:kotest-assertions-core:5.8.1")
     testImplementation("io.kotest:kotest-framework-engine:5.8.1")
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
 }
 
 kotlin{
@@ -103,7 +104,7 @@ tasks.withType<KotlinCompile> {
 tasks.withType<JavaCompile> {
     options.compilerArgs.addAll(listOf(
         "--enable-preview",
-        "-Amapstruct.defaultComponentModel=spring",
+        "-Amapstruct.defaultComponentModel=spring"
     ))
 }
 

--- a/src/main/java/com/example/pawgetherbe/PawgetherBeApplication.java
+++ b/src/main/java/com/example/pawgetherbe/PawgetherBeApplication.java
@@ -2,8 +2,10 @@ package com.example.pawgetherbe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class PawgetherBeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/pawgetherbe/controller/AccountApi.java
+++ b/src/main/java/com/example/pawgetherbe/controller/AccountApi.java
@@ -2,7 +2,7 @@ package com.example.pawgetherbe.controller;
 
 import com.example.pawgetherbe.config.OauthConfig;
 import com.example.pawgetherbe.controller.dto.UserDto.EmailCheckRequest;
-import com.example.pawgetherbe.controller.dto.UserDto.NicknameCheckRequest;
+import com.example.pawgetherbe.controller.dto.UserDto.NickNameCheckRequest;
 import com.example.pawgetherbe.controller.dto.UserDto.UserSignUpRequest;
 import com.example.pawgetherbe.controller.dto.UserDto.UpdateUserRequest;
 import com.example.pawgetherbe.controller.dto.UserDto.UpdateUserResponseBody;
@@ -84,12 +84,12 @@ public class AccountApi {
 
     @PostMapping("/signup/nickname")
     @ResponseStatus(HttpStatus.OK)
-    public void signupNicknameCheck(@RequestBody NicknameCheckRequest nicknameCheckRequest){
-        var nickname = nicknameCheckRequest.nickname();
-        if (!isValidNickName(nickname)) {
+    public void signupNickNameCheck(@RequestBody NickNameCheckRequest nickNameCheckRequest){
+        var nickName = nickNameCheckRequest.nickName();
+        if (!isValidNickName(nickName)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "nickname 은 3~20자의 영문, 숫자, 한글, 언더바(_)만 사용할 수 있습니다.");
         }
-        signUpWithIdUseCase.signupNicknameCheck(nickname);
+        signUpWithIdUseCase.signupNicknameCheck(nickName);
     }
 
     @PatchMapping
@@ -153,7 +153,7 @@ public class AccountApi {
                         oauth2SignUpResponse.accessToken(),
                         oauth2SignUpResponse.provider(),
                         oauth2SignUpResponse.email(),
-                        oauth2SignUpResponse.nickname(),
+                        oauth2SignUpResponse.nickName(),
                         oauth2SignUpResponse.userImg()
                 ));
     }

--- a/src/main/java/com/example/pawgetherbe/controller/AccountApi.java
+++ b/src/main/java/com/example/pawgetherbe/controller/AccountApi.java
@@ -1,6 +1,8 @@
 package com.example.pawgetherbe.controller;
 
 import com.example.pawgetherbe.config.OauthConfig;
+import com.example.pawgetherbe.controller.dto.UserDto.EmailCheckRequest;
+import com.example.pawgetherbe.controller.dto.UserDto.NicknameCheckRequest;
 import com.example.pawgetherbe.controller.dto.UserDto.UserSignUpRequest;
 import com.example.pawgetherbe.controller.dto.UserDto.UpdateUserRequest;
 import com.example.pawgetherbe.controller.dto.UserDto.UpdateUserResponseBody;
@@ -72,7 +74,8 @@ public class AccountApi {
 
     @PostMapping("/signup/email")
     @ResponseStatus(HttpStatus.OK)
-    public void signupEmailCheck(@RequestBody String email){
+    public void signupEmailCheck(@RequestBody EmailCheckRequest emailCheckRequest) {
+        var email = emailCheckRequest.email();
         if (!isValidEmail(email)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "email 형식을 지켜주세요");
         }
@@ -81,7 +84,8 @@ public class AccountApi {
 
     @PostMapping("/signup/nickname")
     @ResponseStatus(HttpStatus.OK)
-    public void signupNicknameCheck(@RequestBody String nickname){
+    public void signupNicknameCheck(@RequestBody NicknameCheckRequest nicknameCheckRequest){
+        var nickname = nicknameCheckRequest.nickname();
         if (!isValidNickName(nickname)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "nickname 은 3~20자의 영문, 숫자, 한글, 언더바(_)만 사용할 수 있습니다.");
         }

--- a/src/main/java/com/example/pawgetherbe/controller/dto/UserDto.java
+++ b/src/main/java/com/example/pawgetherbe/controller/dto/UserDto.java
@@ -1,6 +1,7 @@
 package com.example.pawgetherbe.controller.dto;
 
 import com.example.pawgetherbe.domain.status.UserRole;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -34,7 +35,16 @@ public final class UserDto {
 
     public record UpdateUserResponse(
             String accessToken,
-            String userImg
+            String refreshToken,
+            String userImg,
+            String nickName
+    ) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record UpdateUserResponseBody(
+            String accessToken,
+            String userImg,
+            String nickName
     ) {}
 
     public record Oauth2SignUpResponse(

--- a/src/main/java/com/example/pawgetherbe/controller/dto/UserDto.java
+++ b/src/main/java/com/example/pawgetherbe/controller/dto/UserDto.java
@@ -17,14 +17,14 @@ public final class UserDto {
             String email
     ) {}
 
-    public record NicknameCheckRequest(
-            String nickname
+    public record NickNameCheckRequest(
+            String nickName
     ) {}
 
     public record UserSignUpRequest(
             @NotNull(message = "닉네임을 입력해 주세요")
             @Pattern(regexp = "^[a-zA-Z0-9가-힣_]{3,20}$", message = "닉네임은 영문, 숫자, 한글, 언더바(_)만 사용할 수 있습니다.")
-            String nickname,
+            String nickName,
             @NotNull(message = "이메일을 입력해 주세요")
             @Email(message = "이메일 형식을 지켜주세요")
             String email,
@@ -37,7 +37,7 @@ public final class UserDto {
             ) {}
     public record UpdateUserRequest(
             @Pattern(regexp = "^[a-zA-Z0-9가-힣_]{3,20}$", message = "닉네임은 영문, 숫자, 한글, 언더바(_)만 사용할 수 있습니다.")
-            String nickname,
+            String nickName,
             String userImg
     ) {}
 
@@ -60,7 +60,7 @@ public final class UserDto {
             String refreshToken,
             String provider,
             String email,
-            String nickname,
+            String nickName,
             String userImg
     ) {}
 

--- a/src/main/java/com/example/pawgetherbe/controller/dto/UserDto.java
+++ b/src/main/java/com/example/pawgetherbe/controller/dto/UserDto.java
@@ -13,6 +13,14 @@ public final class UserDto {
             UserRole role
     ) {}
 
+    public record EmailCheckRequest(
+            String email
+    ) {}
+
+    public record NicknameCheckRequest(
+            String nickname
+    ) {}
+
     public record UserSignUpRequest(
             @NotNull(message = "닉네임을 입력해 주세요")
             @Pattern(regexp = "^[a-zA-Z0-9가-힣_]{3,20}$", message = "닉네임은 영문, 숫자, 한글, 언더바(_)만 사용할 수 있습니다.")

--- a/src/main/java/com/example/pawgetherbe/domain/entity/UserEntity.java
+++ b/src/main/java/com/example/pawgetherbe/domain/entity/UserEntity.java
@@ -5,6 +5,8 @@ import com.example.pawgetherbe.domain.status.UserStatus;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -37,6 +39,7 @@ public class UserEntity extends BaseEntity {
     @Column(name = "password", nullable = false, length = 255)
     private String password;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 255)
     private UserStatus status;
 
@@ -46,6 +49,7 @@ public class UserEntity extends BaseEntity {
     @Column(name = "nick_name", length = 255)
     private String nickName;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "role", length = 255)
     private UserRole role;
 

--- a/src/main/java/com/example/pawgetherbe/mapper/UserMapper.java
+++ b/src/main/java/com/example/pawgetherbe/mapper/UserMapper.java
@@ -1,10 +1,10 @@
 package com.example.pawgetherbe.mapper;
 
-import com.example.pawgetherbe.controller.dto.UserDto;
+import com.example.pawgetherbe.controller.dto.UserDto.UserSignUpRequest;
 import com.example.pawgetherbe.domain.entity.UserEntity;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
-    UserEntity toUserEntity(UserDto.UserSignUpRequest userDto);
+    UserEntity toUserEntity(UserSignUpRequest userDto);
 }

--- a/src/main/java/com/example/pawgetherbe/repository/OauthRepository.java
+++ b/src/main/java/com/example/pawgetherbe/repository/OauthRepository.java
@@ -10,9 +10,6 @@ import java.util.Optional;
 public interface OauthRepository extends JpaRepository<OauthEntity, Long> {
     boolean existsByOauthProviderIdAndOauthProvider(String oauthProviderId, String oauthProvider);
     Optional<OauthEntity> findByOauthProviderId(String oauthProviderId);
-    boolean existsByEmail(String email);
-    void deleteByEmail(String email);
-
     boolean existsByUser_Id(Long userId);
     void deleteByUser_Id(Long userId);
 }

--- a/src/main/java/com/example/pawgetherbe/usecase/users/DeleteUserUseCase.java
+++ b/src/main/java/com/example/pawgetherbe/usecase/users/DeleteUserUseCase.java
@@ -1,5 +1,5 @@
 package com.example.pawgetherbe.usecase.users;
 
 public interface DeleteUserUseCase {
-    void deleteAccount(String accessHeader, String refreshToken);
+    void deleteAccount(String refreshToken);
 }

--- a/src/test/kotlin/account/UserServiceTest.kt
+++ b/src/test/kotlin/account/UserServiceTest.kt
@@ -1,0 +1,303 @@
+package account
+import com.example.pawgetherbe.config.OauthConfig
+import com.example.pawgetherbe.controller.dto.UserDto
+import com.example.pawgetherbe.controller.dto.UserDto.UserSignUpRequest
+import com.example.pawgetherbe.domain.UserContext
+import com.example.pawgetherbe.domain.entity.UserEntity
+import com.example.pawgetherbe.domain.status.UserRole
+import com.example.pawgetherbe.domain.status.UserStatus
+import com.example.pawgetherbe.mapper.UserMapper
+import com.example.pawgetherbe.repository.OauthRepository
+import com.example.pawgetherbe.repository.UserRepository
+import com.example.pawgetherbe.service.UserService
+import com.example.pawgetherbe.util.EncryptUtil
+import com.example.pawgetherbe.util.EncryptUtil.passwordEncode
+import com.example.pawgetherbe.util.JwtUtil
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.web.server.ResponseStatusException
+import java.util.*
+
+@ActiveProfiles("test")
+@ExtendWith(SpringExtension::class)
+class UserServiceTest: FreeSpec({
+    lateinit var userRepository: UserRepository
+    lateinit var oauthRepository: OauthRepository
+    lateinit var userMapper: UserMapper
+    lateinit var redisTemplate: RedisTemplate<String, String>
+    lateinit var jwtUtil: JwtUtil
+    lateinit var oauthConfig: OauthConfig
+    lateinit var userService: UserService
+
+    "회원가입" - {
+        "정상적으로 가입" {
+            // Given
+            val signUpRequest = UserSignUpRequest(
+                "tester",
+                "test@example.com",
+                "password123!"
+            )
+            val entity = UserEntity.builder()
+                .nickName("tester")
+                .email("test@example.com")
+                .password("password123")
+                .build()
+
+            val savedEntity = entity.toBuilder()
+                .password(passwordEncode(entity.password))
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.USER_EMAIL)
+                .build()
+
+            every { userMapper.toUserEntity(signUpRequest) } returns entity
+            every { userRepository.save(any()) } returns savedEntity
+
+            // When
+            userService.signUp(signUpRequest)
+
+            // Then
+            val slot = slot<UserEntity>()
+            verify { userRepository.save(capture(slot)) }
+
+            val savedUser = slot.captured
+            savedUser.email shouldBe "test@example.com"
+            savedUser.nickName shouldBe "tester"
+            savedUser.status shouldBe UserStatus.ACTIVE
+            savedUser.role shouldBe UserRole.USER_EMAIL
+        }
+
+        "이메일 중복으로 가입 실패" {
+            // Given
+            val signUpRequest = UserSignUpRequest(
+                "tester",
+                "test@example.com",
+                "password123!"
+            )
+            val entity = UserEntity.builder()
+                .nickName("tester")
+                .email("test@example.com")
+                .password("password123")
+                .build()
+
+            every { userMapper.toUserEntity(signUpRequest) } returns entity
+            every { userRepository.existsByEmail("test@example.com") } returns true
+
+            // When & Then
+            val exception = shouldThrow<ResponseStatusException> {
+                userService.signUp(signUpRequest)
+            }
+
+            exception.statusCode shouldBe HttpStatus.CONFLICT
+            exception.reason shouldBe "이미 가입된 계정입니다"
+
+            verify(exactly = 0) { userRepository.save(any()) }
+        }
+    }
+
+    "이메일 중복 검사" - {
+        "이메일 중복되지 않을떄" {
+            val email = "test@example.com"
+
+            every { userRepository.existsByEmail(email) } returns false
+
+            userService.signupEmailCheck(email)
+        }
+
+        "중복 이메일이면 예외 발생" {
+            val email = "test@example.com"
+
+            every { userRepository.existsByEmail(email) } returns true
+
+            val exception = shouldThrow<ResponseStatusException> {
+                userService.signupEmailCheck(email)
+            }
+
+            exception.statusCode shouldBe HttpStatus.CONFLICT
+            exception.reason shouldBe email + " 이미 가입된 계정입니다."
+        }
+    }
+
+    "닉네임 중복 검사" - {
+        "닉네임이 중복되지 않을때" {
+            val nickName = "tester"
+
+            every { userRepository.existsByNickName(nickName) } returns false
+
+            userService.signupNicknameCheck(nickName)
+        }
+
+        "중복 닉네임이면 예외 발생" {
+            val nickName = "tester"
+
+            every { userRepository.existsByNickName(nickName) } returns true
+
+            val exception = shouldThrow<ResponseStatusException> {
+                userService.signupNicknameCheck(nickName)
+            }
+
+            exception.statusCode shouldBe HttpStatus.CONFLICT
+            exception.reason shouldBe nickName + " 이미 존재하는 닉네임입니다."
+        }
+    }
+
+    "회원 탈퇴" - {
+        "이메일 로그인 가입자" {
+            mockkStatic(UserContext::class)
+            every { UserContext.getUserId() } returns "1"
+
+            val id = UserContext.getUserId().toLong()
+            val refreshToken = "refreshToken123"
+
+            every { UserContext.getUserId() } returns "1"
+            every { oauthRepository.existsByUser_Id(id) } returns false
+            every { userRepository.deleteById(id) } just Runs
+            every { redisTemplate.delete(refreshToken) } returns true
+
+            userService.deleteAccount(refreshToken)
+
+            verify { userRepository.deleteById(1L) }
+            verify { redisTemplate.delete(refreshToken) }
+        }
+
+        "간편 로그인 가입자" {
+            mockkStatic(UserContext::class)
+            every { UserContext.getUserId() } returns "1"
+
+            val id = UserContext.getUserId().toLong()
+            val refreshToken = "refreshToken123"
+
+            every { oauthRepository.existsByUser_Id(id) } returns true
+            every { oauthRepository.deleteByUser_Id(id) } just Runs
+            every { userRepository.deleteById(id) } just Runs
+            every { redisTemplate.delete(refreshToken) } returns true
+
+            userService.deleteAccount(refreshToken)
+
+            verify { oauthRepository.deleteByUser_Id(1L) }
+            verify { userRepository.deleteById(1L) }
+            verify { redisTemplate.delete(refreshToken) }
+        }
+    }
+
+    "로그아웃" - {
+        "refreshToken 삭제 성공" {
+            val refreshToken = "refreshToken123"
+
+            every { redisTemplate.delete(refreshToken) } returns true
+
+            userService.signOut(refreshToken)
+
+            verify { redisTemplate.delete(refreshToken) }
+        }
+        "refreshToken 삭제 실패" {
+            val refreshToken = "refreshToken123"
+            every { redisTemplate.delete(refreshToken) } returns false
+
+            userService.signOut(refreshToken)
+
+            verify { redisTemplate.delete(refreshToken) }
+        }
+    }
+
+    "회원 정보 수정" - {
+        "nickname과 userImg가 업데이트" {
+            mockkStatic(UserContext::class)
+            mockkStatic(EncryptUtil::class)
+
+            every { UserContext.getUserId() } returns "1"
+
+            val newNickname = "newNick"
+            val newUserImg = "newImgUrl"
+            val refreshToken = "refreshToken123"
+            val id = UserContext.getUserId().toLong()
+            val user = UserEntity.builder()
+                .id(1L)
+                .role(UserRole.USER_EMAIL)
+                .status(UserStatus.ACTIVE)
+                .nickName("tester")
+                .userImg("/img/2025/05/05/202505.webp")
+                .email("test@example.com")
+                .password(passwordEncode("password123"))
+                .build()
+
+            every { userRepository.findById(id) } returns Optional.of(user)
+            every { jwtUtil.generateAccessToken(any()) } returns "newAccessToken"
+            every { EncryptUtil.generateRefreshToken() } returns "newRefreshToken"
+            every { redisTemplate.delete(refreshToken) } returns true
+
+            val result = userService.updateUserInfo(
+                UserDto.UpdateUserRequest(newNickname, newUserImg),
+                refreshToken
+            )
+            verify {
+                userRepository.findById(id)
+                user.updateProfile(newNickname, newUserImg)
+                redisTemplate.delete(refreshToken)
+                jwtUtil.generateAccessToken(
+                    withArg { dto ->
+                        dto.id shouldBe user.id
+                        dto.role shouldBe user.role
+                    }
+                )
+            }
+            result.accessToken shouldBe "newAccessToken"
+            result.refreshToken shouldBe "newRefreshToken"
+            result.userImg shouldBe newUserImg
+            result.nickName shouldBe newNickname
+        }
+        "업데이트 실패" {
+            mockkStatic(UserContext::class)
+            mockkStatic(EncryptUtil::class)
+
+            every { UserContext.getUserId() } returns "1"
+            val id = UserContext.getUserId().toLong()
+            val refreshToken = "refreshToken123"
+            val newNickname = "newNick"
+            val newUserImg = "newImgUrl"
+
+            every { userRepository.findById(id) } returns Optional.empty()
+
+            val exception = shouldThrow<ResponseStatusException> {
+                userService.updateUserInfo(
+                    UserDto.UpdateUserRequest(newNickname, newUserImg),
+                    refreshToken
+                )
+            }
+
+            verify(exactly = 0) { redisTemplate.delete(refreshToken) }
+            exception.statusCode shouldBe HttpStatus.NOT_FOUND
+            exception.reason shouldBe " 존재하지 않는 계정입니다."
+        }
+    }
+
+    beforeTest {
+        userRepository = mockk(relaxed = true)
+        oauthRepository = mockk(relaxed = true)
+        userMapper = mockk(relaxed = true)
+        redisTemplate = mockk(relaxed = true)
+        jwtUtil = mockk(relaxed = true)
+        oauthConfig = mockk(relaxed = true)
+
+        userService = UserService(
+            userRepository,
+            oauthRepository,
+            userMapper,
+            redisTemplate,
+            jwtUtil,
+            oauthConfig
+        )
+    }
+})

--- a/src/test/kotlin/com/example/pawgetherbe/account/AccountApiTest.kt
+++ b/src/test/kotlin/com/example/pawgetherbe/account/AccountApiTest.kt
@@ -26,6 +26,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
+import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.patch
@@ -33,8 +34,11 @@ import org.springframework.web.server.ResponseStatusException
 
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension::class)
-@WebMvcTest(AccountApi::class)
-@Import(AccountApiTest.InternalMockConfig::class)
+@WebMvcTest(controllers = [AccountApi::class])
+@ContextConfiguration(classes = [
+    AccountApi::class,
+    AccountApiTest.InternalMockConfig::class
+])
 class AccountApiTest {
 
     @Autowired
@@ -110,7 +114,8 @@ class AccountApiTest {
 
     @Test
     fun `(2xx) 닉네임 중복체크`() {
-        val nickname = UserDto.NicknameCheckRequest("nickname_123")
+        val nickname =
+            UserDto.NickNameCheckRequest("nickname_123")
         mockMvc.post("/api/v1/account/signup/nickname") {
             contentType = MediaType.APPLICATION_JSON
             content = objectMapper.writeValueAsString(nickname)
@@ -121,7 +126,7 @@ class AccountApiTest {
 
     @Test
     fun `(4xx) 닉네임 중복 체크 실패 - 잘못된 형식`() {
-        val request = UserDto.NicknameCheckRequest("**")
+        val request = UserDto.NickNameCheckRequest("**")
 
         mockMvc.post("/api/v1/account/signup/nickname") {
             contentType = MediaType.APPLICATION_JSON

--- a/src/test/kotlin/com/example/pawgetherbe/account/AccountApiTest.kt
+++ b/src/test/kotlin/com/example/pawgetherbe/account/AccountApiTest.kt
@@ -1,0 +1,194 @@
+package com.example.pawgetherbe.account
+
+import com.example.pawgetherbe.config.OauthConfig
+import com.example.pawgetherbe.controller.AccountApi
+import com.example.pawgetherbe.controller.dto.UserDto
+import com.example.pawgetherbe.usecase.users.DeleteUserUseCase
+import com.example.pawgetherbe.usecase.users.EditUserUseCase
+import com.example.pawgetherbe.usecase.users.SignOutUseCase
+import com.example.pawgetherbe.usecase.users.SignUpWithIdUseCase
+import com.example.pawgetherbe.usecase.users.SignUpWithOauthUseCase
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.Cookie
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.patch
+import org.springframework.web.server.ResponseStatusException
+
+@ActiveProfiles("test")
+@ExtendWith(SpringExtension::class)
+@WebMvcTest(AccountApi::class)
+@Import(AccountApiTest.InternalMockConfig::class)
+class AccountApiTest {
+
+    @Autowired
+    private lateinit var editUserUseCase: EditUserUseCase
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @TestConfiguration
+    class InternalMockConfig {
+        @Bean fun signUpWithIdUseCase(): SignUpWithIdUseCase = mock()
+        @Bean fun signUpWithOauthUseCase(): SignUpWithOauthUseCase = mock()
+        @Bean fun deleteUserUseCase(): DeleteUserUseCase = mock()
+        @Bean fun signOutUseCase(): SignOutUseCase = mock()
+        @Bean fun editUserUseCase(): EditUserUseCase = mock()
+        @Bean fun oauthConfig(): OauthConfig = mock()
+    }
+
+
+    @Test
+    fun `(2xx) 회원가입 성공`() {
+        val request = UserDto.UserSignUpRequest("test", "email@test.com", "password123*",)
+        mockMvc.post("/api/v1/account/signup") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+        }.andExpect {
+            status { isCreated() }
+        }
+    }
+
+    @Test
+    fun `(4xx) 회원가입 실패 - 이메일 형식이 잘못됨`() {
+        val request = UserDto.UserSignUpRequest(
+            "nickname123",
+           "email",
+            "password123*"
+        )
+
+        mockMvc.post("/api/v1/account/signup") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+        }.andExpect {
+            status { isBadRequest() }
+        }
+    }
+
+
+    @Test
+    fun `(2xx) 이메일 중복체크`() {
+        val email = UserDto.EmailCheckRequest("email@test.com")
+        mockMvc.post("/api/v1/account/signup/email") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(email)
+        }.andExpect {
+            status { isOk() }
+        }
+    }
+
+    @Test
+    fun `(4xx) 이메일 중복 체크 실패 - 이메일 형식이 아님`() {
+        val request = UserDto.EmailCheckRequest("email")
+
+        mockMvc.post("/api/v1/account/signup/email") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+        }.andExpect {
+            status { isBadRequest() }
+        }
+    }
+
+    @Test
+    fun `(2xx) 닉네임 중복체크`() {
+        val nickname = UserDto.NicknameCheckRequest("nickname_123")
+        mockMvc.post("/api/v1/account/signup/nickname") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(nickname)
+        }.andExpect {
+            status { isOk() }
+        }
+    }
+
+    @Test
+    fun `(4xx) 닉네임 중복 체크 실패 - 잘못된 형식`() {
+        val request = UserDto.NicknameCheckRequest("**")
+
+        mockMvc.post("/api/v1/account/signup/nickname") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+        }.andExpect {
+            status { isBadRequest() }
+        }
+    }
+
+    @Test
+    fun `(2xx) 로그아웃`() {
+        mockMvc.get("/api/v1/account") {
+            cookie(Cookie("refresh_token", "sample-refresh-token"))
+        }.andExpect {
+            status { isNoContent() }
+        }
+    }
+
+    @Test
+    fun `(2xx) 계정 삭제`() {
+        mockMvc.delete("/api/v1/account") {
+            cookie(Cookie("refresh_token", "sample-refresh-token"))
+        }.andExpect {
+            status { isNoContent() }
+        }
+    }
+
+    @Test
+    fun `(2xx) 유저 정보 수정`() {
+        val request = UserDto.UpdateUserRequest("newNick", "img.jpg")
+
+        whenever(editUserUseCase.updateUserInfo(any(), any())).thenReturn(
+            UserDto.UpdateUserResponse(
+                "access123",
+                "refresh123",
+                "img.jpg",
+                "newNick"
+            )
+        )
+
+        mockMvc.patch("/api/v1/account") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+            cookie(Cookie("refresh_token", "refresh123"))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.accessToken") { value("access123") }
+            jsonPath("$.userImg") { value("img.jpg") }
+            jsonPath("$.nickName") { value("newNick") }
+        }
+    }
+
+    @Test
+    fun `(4xx) 유저 정보 수정 실패 - 파라미터 없음`() {
+        val request = UserDto.UpdateUserRequest("newNick", "img.jpg")
+
+        whenever(editUserUseCase.updateUserInfo(any(), any()))
+            .thenThrow(
+                ResponseStatusException(HttpStatus.NOT_FOUND, " 존재하지 않는 계정입니다.")
+            )
+
+        mockMvc.patch("/api/v1/account") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+            cookie(Cookie("refresh_token", "refresh123"))
+        }.andExpect {
+            status { isNotFound() }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/pawgetherbe/account/UserServiceTest.kt
+++ b/src/test/kotlin/com/example/pawgetherbe/account/UserServiceTest.kt
@@ -1,4 +1,4 @@
-package account
+package com.example.pawgetherbe.account
 import com.example.pawgetherbe.config.OauthConfig
 import com.example.pawgetherbe.controller.dto.UserDto
 import com.example.pawgetherbe.controller.dto.UserDto.UserSignUpRequest

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,27 @@
+spring:
+  application:
+    name: pawgether-be
+
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: test
+    password:
+    driver-class-name: org.h2.Driver
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+
+jwt:
+  secret-key: s4KJ29A0fslDkj3RnlqpsueuFFaw8fG3D2lgq9XsQak=


### PR DESCRIPTION
## 작업 목록

- [x] 회원 탈퇴 로직 수정, 회원 정보 수정 로직 수정
- [x] 회원가입시 체크 로직 추가
- [x] 닉네임 중복체크 기능 수정, 이메일 중복체크 기능 수정
- [x] nickname을 nickName으로 변경
- [x] OauthRepository에 existsByEmail, deleteByEmail 삭제
- [x] PawgetherBeApplication 에 @EnableJpaAuditing 설정 추가
- [x] UserEntity EnumType 타입에 @Enumerated(EnumType.STRING) 추가
- [x] UserService 메서드에 누락된 @transactional 추가 및 업데이트 로직에 누락된 redisTemplate 에 저장 로직 추가

## 부연설명

- **회원 탈퇴 로직 수정, 회원 정보 수정 로직 수정** 
  - 회원 탈퇴 api 파라미터를 accessToken -> refreshToken 으로 변경
  - 회원 정보 api 를 반환시 토큰 및 user정보도 같이 return하도록 변경
  - UpdateUserResponseBody Dto 생성
  - 회원 탈퇴 및 회원정보 서비스 로직에서 UserContext사용

- **회원가입시 체크 로직 추가**
  - signUp 서비스 로직에 email로 체크로직 추가

- **PawgetherBeApplication**
  - @EnableJpaAuditing 설정 추가하여 Jpa가 시간 자동 insert되도록 활성화 

- nickname을 엔티티와 맵핑을 위해 nickName으로 변경

## Test

- UserServiceTest 구현
- UserServiceTest 패키지 구조 변경
- AccountApiTest 구현
- WebMvcTest 및 ContextConfiguration 설정 추가