### PR TITLE
Feature/petfair main and calendar

### DIFF
--- a/src/main/java/com/example/pawgetherbe/config/QueryDslConfig.java
+++ b/src/main/java/com/example/pawgetherbe/config/QueryDslConfig.java
@@ -1,7 +1,19 @@
 package com.example.pawgetherbe.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
 }

--- a/src/main/java/com/example/pawgetherbe/controller/command/AccountCommandApi.java
+++ b/src/main/java/com/example/pawgetherbe/controller/command/AccountCommandApi.java
@@ -2,6 +2,7 @@ package com.example.pawgetherbe.controller.command;
 
 import com.example.pawgetherbe.common.exceptionHandler.CustomException;
 import com.example.pawgetherbe.config.OauthConfig;
+import com.example.pawgetherbe.controller.command.dto.UserCommandDto.PasswordEditRequest;
 import com.example.pawgetherbe.controller.command.dto.UserCommandDto.OAuth2ResponseBody;
 import com.example.pawgetherbe.controller.command.dto.UserCommandDto.SignInUserRequest;
 import com.example.pawgetherbe.controller.command.dto.UserCommandDto.SignInUserResponse;
@@ -156,5 +157,10 @@ public class AccountCommandApi {
                 .maxAge(REFRESH_TOKEN_VALIDITY_SECONDS)
                 .sameSite(SAME_SITE_STRICT)
                 .build();
+    }
+
+    @PatchMapping("/password")
+    public void editPassword(@RequestBody @Valid PasswordEditRequest passwordEditRequest) {
+        editUserCommandUseCase.updatePassword(passwordEditRequest);
     }
 }

--- a/src/main/java/com/example/pawgetherbe/controller/command/dto/UserCommandDto.java
+++ b/src/main/java/com/example/pawgetherbe/controller/command/dto/UserCommandDto.java
@@ -90,17 +90,16 @@ public final class UserCommandDto {
     ) {}
 
     public record PasswordEditRequest(
-            //        @Pattern(
-//                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^*()_+=\\-._~])[A-Za-z\\d!@#$%^*()_+=\\-._~]{8,}$",
-//                message = "비밀번호는 영문, 숫자, 특수문자를 포함해 8자 이상 입력해주세요"
-//        )
-            @Size(min = 8)
+            @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^*()_+=\\-._~])[A-Za-z\\d!@#$%^*()_+=\\-._~]{8,}$",
+                message = "비밀번호는 영문, 숫자, 특수문자를 포함해 8자 이상 입력해주세요"
+            )
             String password,
-            //        @Pattern(
-//                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^*()_+=\\-._~])[A-Za-z\\d!@#$%^*()_+=\\-._~]{8,}$",
-//                message = "비밀번호는 영문, 숫자, 특수문자를 포함해 8자 이상 입력해주세요"
-//        )
-            @Size(min = 8)
+
+            @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^*()_+=\\-._~])[A-Za-z\\d!@#$%^*()_+=\\-._~]{8,}$",
+                message = "비밀번호는 영문, 숫자, 특수문자를 포함해 8자 이상 입력해주세요"
+            )
             String newPassword
     ) {}
 }

--- a/src/main/java/com/example/pawgetherbe/controller/command/dto/UserCommandDto.java
+++ b/src/main/java/com/example/pawgetherbe/controller/command/dto/UserCommandDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 public final class UserCommandDto {
 
@@ -22,10 +23,11 @@ public final class UserCommandDto {
             @Email(message = "이메일 형식을 지켜주세요")
             String email,
             @NotNull(message = "비밀번호를 입력해주세요")
-            @Pattern(
-                    regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-])[A-Za-z\\d!@#$%^&*()_+=-]{8,20}$",
-                    message = "비밀번호는 영문, 숫자, 특수문자를 포함해 8~20자로 입력해주세요"
-            )
+//            @Pattern(
+//                    regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^*()_+=\\-._~])[A-Za-z\\d!@#$%^*()_+=\\-._~]{8,}$",
+//                    message = "비밀번호는 영문, 숫자, 특수문자를 포함해 8자 이상 입력해주세요"
+//            )
+            @Size(min = 8)
             String password
             ) {}
     public record UpdateUserRequest(
@@ -39,10 +41,11 @@ public final class UserCommandDto {
         @Email(message = "이메일 형식을 지켜주세요")
         String email,
         @NotBlank(message = "비밀번호를 입력해주세요")
-        @Pattern(
-                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-])[A-Za-z\\d!@#$%^&*()_+=-]{8,20}$",
-                message = "비밀번호는 영문, 숫자, 특수문자를 포함해 8~20자로 입력해주세요"
-        )
+//        @Pattern(
+//                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^*()_+=\\-._~])[A-Za-z\\d!@#$%^*()_+=\\-._~]{8,}$",
+//                message = "비밀번호는 영문, 숫자, 특수문자를 포함해 8자 이상 입력해주세요"
+//        )
+        @Size(min = 8)
         String password
     ) {}
 
@@ -84,5 +87,20 @@ public final class UserCommandDto {
             String email,
             String nickName,
             String userImg
+    ) {}
+
+    public record PasswordEditRequest(
+            //        @Pattern(
+//                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^*()_+=\\-._~])[A-Za-z\\d!@#$%^*()_+=\\-._~]{8,}$",
+//                message = "비밀번호는 영문, 숫자, 특수문자를 포함해 8자 이상 입력해주세요"
+//        )
+            @Size(min = 8)
+            String password,
+            //        @Pattern(
+//                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^*()_+=\\-._~])[A-Za-z\\d!@#$%^*()_+=\\-._~]{8,}$",
+//                message = "비밀번호는 영문, 숫자, 특수문자를 포함해 8자 이상 입력해주세요"
+//        )
+            @Size(min = 8)
+            String newPassword
     ) {}
 }

--- a/src/main/java/com/example/pawgetherbe/controller/query/PetFairCalendarQueryApi.java
+++ b/src/main/java/com/example/pawgetherbe/controller/query/PetFairCalendarQueryApi.java
@@ -1,0 +1,23 @@
+package com.example.pawgetherbe.controller.query;
+
+import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto.PetFairCalendarResponse;
+import com.example.pawgetherbe.usecase.post.ReadPostsUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/calendar")
+public class PetFairCalendarQueryApi {
+
+    private final ReadPostsUseCase readPostsUseCase;
+
+    @GetMapping
+    public PetFairCalendarResponse petFairCalendar(String date) {
+        return readPostsUseCase.petFairCalendar(date);
+    }
+}

--- a/src/main/java/com/example/pawgetherbe/controller/query/PetFairMainQueryApi.java
+++ b/src/main/java/com/example/pawgetherbe/controller/query/PetFairMainQueryApi.java
@@ -1,0 +1,23 @@
+package com.example.pawgetherbe.controller.query;
+
+import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto.PetFairCarouselResponse;
+import com.example.pawgetherbe.usecase.post.ReadPostsUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/main")
+public class PetFairMainQueryApi {
+
+    private final ReadPostsUseCase readPostsUseCase;
+
+    @GetMapping("/carousel")
+    public PetFairCarouselResponse petFairCarousel() {
+        return readPostsUseCase.petFairCarousel();
+    }
+}

--- a/src/main/java/com/example/pawgetherbe/controller/query/dto/PetFairQueryDto.java
+++ b/src/main/java/com/example/pawgetherbe/controller/query/dto/PetFairQueryDto.java
@@ -1,0 +1,12 @@
+package com.example.pawgetherbe.controller.query.dto;
+
+import java.util.List;
+
+public final class PetFairQueryDto {
+
+    public record PetFairCarouselResponse(
+            List<PetFairPosterDto> petFairImages
+    ) {}
+
+    public record PetFairPosterDto(Long petFairId, String posterImageUrl) {}
+}

--- a/src/main/java/com/example/pawgetherbe/controller/query/dto/PetFairQueryDto.java
+++ b/src/main/java/com/example/pawgetherbe/controller/query/dto/PetFairQueryDto.java
@@ -1,5 +1,6 @@
 package com.example.pawgetherbe.controller.query.dto;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public final class PetFairQueryDto {
@@ -8,5 +9,22 @@ public final class PetFairQueryDto {
             List<PetFairPosterDto> petFairImages
     ) {}
 
-    public record PetFairPosterDto(Long petFairId, String posterImageUrl) {}
+    public record PetFairCalendarResponse(
+            List<PetFairCalendarDto> petFairs
+    ) {}
+
+    public record PetFairPosterDto(
+            Long petFairId,
+            String posterImageUrl
+    ) {}
+
+    public record PetFairCalendarDto(
+        Long petFairId,
+        Long counter,
+        String title,
+        String posterImageUrl,
+        LocalDate startDate,
+        LocalDate endDate,
+        String simpleAddress
+    ) {}
 }

--- a/src/main/java/com/example/pawgetherbe/domain/entity/PetFairEntity.java
+++ b/src/main/java/com/example/pawgetherbe/domain/entity/PetFairEntity.java
@@ -1,8 +1,11 @@
 package com.example.pawgetherbe.domain.entity;
 
+import com.example.pawgetherbe.domain.status.PetFairStatus;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -78,13 +81,15 @@ public class PetFairEntity extends BaseEntity {
     private String telNumber;
 
     @Column(name = "status", length = 255)
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private PetFairStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
 
     @OneToMany(mappedBy="petFair", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @Builder.Default
     private List<PetFairImageEntity> pairImages = new ArrayList<>();
 
     @OneToMany(mappedBy="petFair", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
@@ -92,4 +97,9 @@ public class PetFairEntity extends BaseEntity {
 
     @OneToMany(mappedBy="petFair", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<BookmarkEntity> bookmarkEntities = new ArrayList<>();
+
+    public void addImage(PetFairImageEntity image) {
+        pairImages.add(image);
+        image.setPetFair(this);
+    }
 }

--- a/src/main/java/com/example/pawgetherbe/domain/entity/UserEntity.java
+++ b/src/main/java/com/example/pawgetherbe/domain/entity/UserEntity.java
@@ -79,4 +79,8 @@ public class UserEntity extends BaseEntity {
     public void updateRole(UserRole role) {
         this.role = role;
     }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/example/pawgetherbe/domain/status/PetFairStatus.java
+++ b/src/main/java/com/example/pawgetherbe/domain/status/PetFairStatus.java
@@ -1,0 +1,6 @@
+package com.example.pawgetherbe.domain.status;
+
+public enum PetFairStatus {
+    ACTIVE,
+    REMOVED
+}

--- a/src/main/java/com/example/pawgetherbe/exception/command/UserCommandErrorCode.java
+++ b/src/main/java/com/example/pawgetherbe/exception/command/UserCommandErrorCode.java
@@ -9,6 +9,8 @@ public enum UserCommandErrorCode implements ErrorCode {
 
     NOT_FOUND_USER(HttpStatus.NOT_FOUND,"NOT_FOUND_USER","존재하지 않는 계정입니다."),
 
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "PASSWORD_MISMATCH", "비밀번호가 일치하지 않습니다."),
+
     OAUTH_PROVIDER_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "OAUTH_PROVIDER_NOT_SUPPORTED", "지원하지 않는 OAuth2 입니다."),
 
     CONFLICT_EMAIL(HttpStatus.CONFLICT, "CONFLICT_EMAIL", "이미 존재하는 Email 입니다."),

--- a/src/main/java/com/example/pawgetherbe/exception/query/PetFairQueryErrorCode.java
+++ b/src/main/java/com/example/pawgetherbe/exception/query/PetFairQueryErrorCode.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum PetFairQueryErrorCode implements ErrorCode {
     NOT_FOUND_PET_FAIR_POSTER(HttpStatus.NOT_FOUND, "NOT_FOUND_PET_FAIR_POSTER", "펫페어 포스터가 없습니다."),
+    NOT_FOUND_PET_FAIR_CALENDAR(HttpStatus.NOT_FOUND, "NOT_FOUND_PET_FAIR_CALENDAR", "펫페어 행사가 없습니다."),
+
     ;
 
     private final String message;

--- a/src/main/java/com/example/pawgetherbe/exception/query/PetFairQueryErrorCode.java
+++ b/src/main/java/com/example/pawgetherbe/exception/query/PetFairQueryErrorCode.java
@@ -1,0 +1,34 @@
+package com.example.pawgetherbe.exception.query;
+
+import com.example.pawgetherbe.common.exceptionHandler.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum PetFairQueryErrorCode implements ErrorCode {
+    NOT_FOUND_PET_FAIR_POSTER(HttpStatus.NOT_FOUND, "NOT_FOUND_PET_FAIR_POSTER", "펫페어 포스터가 없습니다."),
+    ;
+
+    private final String message;
+    private final String code;
+    private final HttpStatus httpStatus;
+
+    PetFairQueryErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.message = message;
+        this.code = code;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/example/pawgetherbe/repository/query/PetFairQueryDSLRepository.java
+++ b/src/main/java/com/example/pawgetherbe/repository/query/PetFairQueryDSLRepository.java
@@ -1,0 +1,34 @@
+package com.example.pawgetherbe.repository.query;
+
+import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto.PetFairPosterDto;
+import com.example.pawgetherbe.domain.entity.QPetFairEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PetFairQueryDSLRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final QPetFairEntity petFair = QPetFairEntity.petFairEntity;
+
+    @Transactional(readOnly = true)
+    public List<PetFairPosterDto> petFairCarousel() {
+        var today = java.time.LocalDate.now();
+
+        return jpaQueryFactory
+                .select(petFair.id, petFair.posterImageUrl)
+                .from(petFair)
+                .where(petFair.endDate.goe(today))
+                .orderBy(petFair.startDate.asc(), petFair.id.asc())
+                .limit(10)
+                .fetch()
+                .stream()
+                .map(t -> new PetFairPosterDto(t.get(petFair.id), t.get(petFair.posterImageUrl)))
+                .toList();
+    }
+}

--- a/src/main/java/com/example/pawgetherbe/repository/query/PetFairQueryDSLRepository.java
+++ b/src/main/java/com/example/pawgetherbe/repository/query/PetFairQueryDSLRepository.java
@@ -1,12 +1,16 @@
 package com.example.pawgetherbe.repository.query;
 
+import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto;
 import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto.PetFairPosterDto;
 import com.example.pawgetherbe.domain.entity.QPetFairEntity;
+import com.example.pawgetherbe.domain.status.PetFairStatus;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
@@ -23,12 +27,42 @@ public class PetFairQueryDSLRepository {
         return jpaQueryFactory
                 .select(petFair.id, petFair.posterImageUrl)
                 .from(petFair)
-                .where(petFair.endDate.goe(today))
-                .orderBy(petFair.startDate.asc(), petFair.id.asc())
+                .where(
+                        petFair.endDate.goe(today)
+                                .and(petFair.status.eq(PetFairStatus.ACTIVE))
+                )
+                .orderBy(petFair.startDate.desc())
                 .limit(10)
                 .fetch()
                 .stream()
                 .map(t -> new PetFairPosterDto(t.get(petFair.id), t.get(petFair.posterImageUrl)))
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<PetFairQueryDto.PetFairCalendarDto> petFairCalendar(String date) {
+        var CalendarDate = LocalDate.parse(date);
+        LocalDate startDate = CalendarDate.minusMonths(6);
+        LocalDate endDate   = CalendarDate.plusMonths(6);
+
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        PetFairQueryDto.PetFairCalendarDto.class,
+                        petFair.id,                                  // Long petFairId
+                        petFair.counter.coalesce(0L),               // Long counter (NULL 방지)
+                        petFair.title,                              // String title
+                        petFair.posterImageUrl,                     // String posterImageUrl
+                        petFair.startDate,                          // LocalDate startDate
+                        petFair.endDate,                            // LocalDate endDate
+                        petFair.simpleAddress
+                ))
+                .from(petFair)
+                .where(
+                        petFair.status.eq(PetFairStatus.ACTIVE),
+                        petFair.startDate.loe(endDate),           // 시작일이 윈도우 끝보다 같거나 이른 것
+                        petFair.endDate.goe(startDate)            // 종료일이 윈도우 시작보다 같거나 늦은 것
+                )
+                .orderBy(petFair.startDate.desc())
+                .fetch();
     }
 }

--- a/src/main/java/com/example/pawgetherbe/service/query/PetFairMainQueryService.java
+++ b/src/main/java/com/example/pawgetherbe/service/query/PetFairMainQueryService.java
@@ -1,0 +1,28 @@
+package com.example.pawgetherbe.service.query;
+
+import com.example.pawgetherbe.common.exceptionHandler.CustomException;
+import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto.PetFairCarouselResponse;
+import com.example.pawgetherbe.repository.query.PetFairQueryDSLRepository;
+import com.example.pawgetherbe.usecase.post.ReadPostsUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import static com.example.pawgetherbe.exception.query.PetFairQueryErrorCode.NOT_FOUND_PET_FAIR_POSTER;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PetFairMainQueryService implements ReadPostsUseCase {
+
+    private final PetFairQueryDSLRepository petFairQueryDSLRepository;
+
+    @Override
+    public PetFairCarouselResponse petFairCarousel() {
+        var petFairCarousel = petFairQueryDSLRepository.petFairCarousel();
+        if (petFairCarousel == null) {
+            throw new CustomException(NOT_FOUND_PET_FAIR_POSTER);
+        }
+        return new PetFairCarouselResponse(petFairCarousel);
+    }
+}

--- a/src/main/java/com/example/pawgetherbe/service/query/PetFairQueryService.java
+++ b/src/main/java/com/example/pawgetherbe/service/query/PetFairQueryService.java
@@ -1,6 +1,7 @@
 package com.example.pawgetherbe.service.query;
 
 import com.example.pawgetherbe.common.exceptionHandler.CustomException;
+import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto.PetFairCalendarResponse;
 import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto.PetFairCarouselResponse;
 import com.example.pawgetherbe.repository.query.PetFairQueryDSLRepository;
 import com.example.pawgetherbe.usecase.post.ReadPostsUseCase;
@@ -8,12 +9,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import static com.example.pawgetherbe.exception.query.PetFairQueryErrorCode.NOT_FOUND_PET_FAIR_CALENDAR;
 import static com.example.pawgetherbe.exception.query.PetFairQueryErrorCode.NOT_FOUND_PET_FAIR_POSTER;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class PetFairMainQueryService implements ReadPostsUseCase {
+public class PetFairQueryService implements ReadPostsUseCase {
 
     private final PetFairQueryDSLRepository petFairQueryDSLRepository;
 
@@ -24,5 +26,14 @@ public class PetFairMainQueryService implements ReadPostsUseCase {
             throw new CustomException(NOT_FOUND_PET_FAIR_POSTER);
         }
         return new PetFairCarouselResponse(petFairCarousel);
+    }
+
+    @Override
+    public PetFairCalendarResponse petFairCalendar(String date) {
+        var petFairCalendar = petFairQueryDSLRepository.petFairCalendar(date);
+        if (petFairCalendar == null) {
+            throw new CustomException(NOT_FOUND_PET_FAIR_CALENDAR);
+        }
+        return new PetFairCalendarResponse(petFairCalendar);
     }
 }

--- a/src/main/java/com/example/pawgetherbe/service/query/PetFairQueryService.java
+++ b/src/main/java/com/example/pawgetherbe/service/query/PetFairQueryService.java
@@ -22,7 +22,7 @@ public class PetFairQueryService implements ReadPostsUseCase {
     @Override
     public PetFairCarouselResponse petFairCarousel() {
         var petFairCarousel = petFairQueryDSLRepository.petFairCarousel();
-        if (petFairCarousel == null) {
+        if (petFairCarousel == null || petFairCarousel.isEmpty()) {
             throw new CustomException(NOT_FOUND_PET_FAIR_POSTER);
         }
         return new PetFairCarouselResponse(petFairCarousel);
@@ -31,7 +31,7 @@ public class PetFairQueryService implements ReadPostsUseCase {
     @Override
     public PetFairCalendarResponse petFairCalendar(String date) {
         var petFairCalendar = petFairQueryDSLRepository.petFairCalendar(date);
-        if (petFairCalendar == null) {
+        if (petFairCalendar == null || petFairCalendar.isEmpty()) {
             throw new CustomException(NOT_FOUND_PET_FAIR_CALENDAR);
         }
         return new PetFairCalendarResponse(petFairCalendar);

--- a/src/main/java/com/example/pawgetherbe/usecase/post/ReadPostsUseCase.java
+++ b/src/main/java/com/example/pawgetherbe/usecase/post/ReadPostsUseCase.java
@@ -1,4 +1,7 @@
 package com.example.pawgetherbe.usecase.post;
 
+import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto.PetFairCarouselResponse;
+
 public interface ReadPostsUseCase {
+    PetFairCarouselResponse petFairCarousel();
 }

--- a/src/main/java/com/example/pawgetherbe/usecase/post/ReadPostsUseCase.java
+++ b/src/main/java/com/example/pawgetherbe/usecase/post/ReadPostsUseCase.java
@@ -1,7 +1,9 @@
 package com.example.pawgetherbe.usecase.post;
 
+import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto.PetFairCalendarResponse;
 import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto.PetFairCarouselResponse;
 
 public interface ReadPostsUseCase {
     PetFairCarouselResponse petFairCarousel();
+    PetFairCalendarResponse petFairCalendar(String date);
 }

--- a/src/main/java/com/example/pawgetherbe/usecase/users/command/EditUserCommandUseCase.java
+++ b/src/main/java/com/example/pawgetherbe/usecase/users/command/EditUserCommandUseCase.java
@@ -1,8 +1,10 @@
 package com.example.pawgetherbe.usecase.users.command;
 
+import com.example.pawgetherbe.controller.command.dto.UserCommandDto.PasswordEditRequest;
 import com.example.pawgetherbe.controller.command.dto.UserCommandDto.UpdateUserRequest;
 import com.example.pawgetherbe.controller.command.dto.UserCommandDto.UpdateUserResponse;
 
 public interface EditUserCommandUseCase {
     UpdateUserResponse updateUserInfo(UpdateUserRequest request);
+    void updatePassword(PasswordEditRequest passwordEditRequest);
 }

--- a/src/test/kotlin/com/example/pawgetherbe/account/PetFairCalendarQueryApiTest.kt
+++ b/src/test/kotlin/com/example/pawgetherbe/account/PetFairCalendarQueryApiTest.kt
@@ -1,0 +1,74 @@
+package com.example.pawgetherbe.account
+
+import com.example.pawgetherbe.common.exceptionHandler.CustomException
+import com.example.pawgetherbe.common.exceptionHandler.GlobalExceptionHandler
+import com.example.pawgetherbe.controller.query.PetFairCalendarQueryApi
+import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto
+import com.example.pawgetherbe.usecase.post.ReadPostsUseCase
+import io.kotest.core.spec.style.FreeSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+import com.example.pawgetherbe.exception.query.PetFairQueryErrorCode.NOT_FOUND_PET_FAIR_CALENDAR
+
+@ActiveProfiles("test")
+@WebMvcTest(PetFairCalendarQueryApi::class)
+@Import(GlobalExceptionHandler::class)
+class PetFairCalendarQueryApiTest: FreeSpec({
+
+    lateinit var mockMvc: MockMvc
+    lateinit var petFairCalendarQueryApi: PetFairCalendarQueryApi
+    lateinit var readPostsUseCase: ReadPostsUseCase
+
+    beforeTest {
+        readPostsUseCase = mockk()
+
+        petFairCalendarQueryApi = PetFairCalendarQueryApi(readPostsUseCase)
+
+        mockMvc = MockMvcBuilders.standaloneSetup(petFairCalendarQueryApi)
+            .setControllerAdvice(GlobalExceptionHandler())
+            .build()
+    }
+
+    "Calendar 조회" - {
+        "Calendar 조회 성공" {
+            val petFairCalendars = listOf(
+                PetFairQueryDto.PetFairCalendarDto(1L, 100L, "PetFair 1", "images/poster/2025/05/0505.webp",
+                    LocalDate.of(2025, 5, 5), LocalDate.of(2025, 5, 6), "경기도 고양시 킨텍스"),
+                PetFairQueryDto.PetFairCalendarDto(2L, 200L, "PetFair 2", "images/poster/2025/07/0715.webp",
+                    LocalDate.of(2025, 7, 15), LocalDate.of(2025, 7, 16), "서울 삼성동 코엑스")
+            )
+            val petFairCalendarResponse = PetFairQueryDto.PetFairCalendarResponse(petFairCalendars)
+
+            every { readPostsUseCase.petFairCalendar(any()) } returns petFairCalendarResponse
+
+            mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/calendar")
+                .param("date", "2025-05-05"))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.petFairs[0].petFairId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.petFairs[1].posterImageUrl").value("images/poster/2025/07/0715.webp"))
+            verify(exactly = 1) { readPostsUseCase.petFairCalendar(any()) }
+        }
+        "Calendar 조회 실패" {
+            every { readPostsUseCase.petFairCalendar(any()) } throws CustomException(NOT_FOUND_PET_FAIR_CALENDAR)
+
+            mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/calendar")
+                .param("date", "2025-05-05"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("NOT_FOUND_PET_FAIR_CALENDAR"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("펫페어 행사가 없습니다."))
+
+            verify(exactly = 1) { readPostsUseCase.petFairCalendar(any()) }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/pawgetherbe/account/PetFairMainQueryApiTest.kt
+++ b/src/test/kotlin/com/example/pawgetherbe/account/PetFairMainQueryApiTest.kt
@@ -1,0 +1,72 @@
+package com.example.pawgetherbe.account
+
+import com.example.pawgetherbe.common.exceptionHandler.CustomException
+import com.example.pawgetherbe.common.exceptionHandler.GlobalExceptionHandler
+import com.example.pawgetherbe.controller.query.PetFairMainQueryApi
+import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto
+import com.example.pawgetherbe.usecase.post.ReadPostsUseCase
+import io.kotest.core.spec.style.FreeSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import com.example.pawgetherbe.exception.query.PetFairQueryErrorCode.NOT_FOUND_PET_FAIR_POSTER
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+
+@ActiveProfiles("test")
+@WebMvcTest(PetFairMainQueryApi::class)
+@Import(GlobalExceptionHandler::class)
+class PetFairMainQueryApiTest: FreeSpec({
+
+    lateinit var mockMvc: MockMvc
+    lateinit var readPostsUseCase: ReadPostsUseCase
+    lateinit var petFairMainQueryApi: PetFairMainQueryApi
+
+    beforeTest {
+        readPostsUseCase = mockk()
+
+        petFairMainQueryApi = PetFairMainQueryApi(readPostsUseCase)
+
+        mockMvc = MockMvcBuilders.standaloneSetup(petFairMainQueryApi)
+            .setControllerAdvice(GlobalExceptionHandler())
+            .build()
+    }
+
+    "Carousel 조회" - {
+        "Carousel 조회 성공" {
+            val petFairImages = listOf(
+                PetFairQueryDto.PetFairPosterDto(1L, "images/poster/2025/05/0505.webp"),
+                PetFairQueryDto.PetFairPosterDto(2L, "images/poster/2025/07/0715.webp"),
+                PetFairQueryDto.PetFairPosterDto(3L, "images/poster/2025/08/0805.webp")
+            )
+            val petFairCarouselResponse = PetFairQueryDto.PetFairCarouselResponse(petFairImages)
+
+            every { readPostsUseCase.petFairCarousel() } returns petFairCarouselResponse
+
+            mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/main/carousel"))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.petFairImages[0].petFairId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.petFairImages[1].posterImageUrl").value("images/poster/2025/07/0715.webp"))
+
+            verify(exactly = 1) { readPostsUseCase.petFairCarousel() }
+        }
+
+        "Carousel 조회 없음" {
+            every { readPostsUseCase.petFairCarousel() } throws CustomException(NOT_FOUND_PET_FAIR_POSTER)
+
+            mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/main/carousel"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("NOT_FOUND_PET_FAIR_POSTER"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("펫페어 포스터가 없습니다."))
+
+            verify(exactly = 1) { readPostsUseCase.petFairCarousel() }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/pawgetherbe/account/PetFairQueryServiceTest.kt
+++ b/src/test/kotlin/com/example/pawgetherbe/account/PetFairQueryServiceTest.kt
@@ -1,0 +1,115 @@
+package com.example.pawgetherbe.account
+
+import com.example.pawgetherbe.common.exceptionHandler.CustomException
+import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto
+import com.example.pawgetherbe.controller.query.dto.PetFairQueryDto.PetFairCarouselResponse
+import com.example.pawgetherbe.repository.query.PetFairQueryDSLRepository
+import com.example.pawgetherbe.service.query.PetFairQueryService
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.time.LocalDate
+
+@ActiveProfiles("test")
+@ExtendWith(SpringExtension::class)
+class PetFairQueryServiceTest: FreeSpec ({
+    lateinit var petFairQueryService: PetFairQueryService
+    lateinit var petFairQueryDSLRepository: PetFairQueryDSLRepository
+
+    "Carousel 조회" - {
+        "Carousel 조회 성공" {
+            val petFairImages = listOf(
+                PetFairQueryDto.PetFairPosterDto(1L, "images/poster/2025/05/0505.webp"),
+                PetFairQueryDto.PetFairPosterDto(2L, "images/poster/2025/07/0715.webp"),
+                PetFairQueryDto.PetFairPosterDto(3L, "images/poster/2025/08/0805.webp"),
+                PetFairQueryDto.PetFairPosterDto(4L, "images/poster/2025/09/0915.webp"),
+                PetFairQueryDto.PetFairPosterDto(5L, "images/poster/2025/10/1005.webp"),
+                PetFairQueryDto.PetFairPosterDto(6L, "images/poster/2025/11/1115.webp"),
+                PetFairQueryDto.PetFairPosterDto(7L, "images/poster/2025/12/1205.webp"),
+                PetFairQueryDto.PetFairPosterDto(8L, "images/poster/2025/1/0115.webp"),
+                PetFairQueryDto.PetFairPosterDto(9L, "images/poster/2025/2/0205.webp"),
+                PetFairQueryDto.PetFairPosterDto(10L, "images/poster/2025/3/0315.webp"),
+            )
+            val petFairCarouselResponse = PetFairCarouselResponse(petFairImages)
+
+            every { petFairQueryDSLRepository.petFairCarousel() } returns petFairImages
+
+            val res = petFairQueryService.petFairCarousel()
+
+            res shouldBe petFairCarouselResponse
+            res.petFairImages shouldBe petFairCarouselResponse.petFairImages
+
+            verify(exactly = 1) { petFairQueryDSLRepository.petFairCarousel() }
+
+        }
+
+        "Carousel 조회 없음" {
+            val petFairImages = emptyList<PetFairQueryDto.PetFairPosterDto>()
+
+            every { petFairQueryDSLRepository.petFairCarousel() } returns petFairImages
+
+            val exception = shouldThrow<CustomException> {
+                petFairQueryService.petFairCarousel()
+            }
+
+            verify(exactly = 1) { petFairQueryDSLRepository.petFairCarousel() }
+
+            val errorCode = exception.errorCode
+            errorCode.message() shouldBe "펫페어 포스터가 없습니다."
+            errorCode.httpStatus() shouldBe HttpStatus.NOT_FOUND
+            errorCode.code() shouldBe "NOT_FOUND_PET_FAIR_POSTER"
+        }
+    }
+
+    "Calendar 조회" - {
+        "Calendar 조회 성공" {
+            val petFairCalendars = listOf(
+                PetFairQueryDto.PetFairCalendarDto(1L, 100L, "PetFair 1", "images/poster/2025/05/0505.webp",
+                    LocalDate.of(2025, 5, 5), LocalDate.of(2025, 5, 6), "경기도 고양시 킨텍스"),
+                PetFairQueryDto.PetFairCalendarDto(2L, 200L, "PetFair 2", "images/poster/2025/07/0715.webp",
+                    LocalDate.of(2025, 7, 15), LocalDate.of(2025, 7, 16), "서울 삼성동 코엑스")
+            )
+            val petFairCalendarResponse = PetFairQueryDto.PetFairCalendarResponse(petFairCalendars)
+
+            every { petFairQueryDSLRepository.petFairCalendar(any()) } returns petFairCalendars
+
+            val res = petFairQueryService.petFairCalendar("2025-08-29")
+
+            res.petFairs shouldBe petFairCalendarResponse.petFairs
+            res shouldBe petFairCalendarResponse
+
+            verify(exactly = 1) { petFairQueryDSLRepository.petFairCalendar(any()) }
+
+        }
+        "Calendar 조회 실패" {
+            val petFairCalendars = emptyList<PetFairQueryDto.PetFairCalendarDto>()
+
+            every { petFairQueryDSLRepository.petFairCalendar(any()) } returns petFairCalendars
+
+            val exception = shouldThrow<CustomException> {
+                petFairQueryService.petFairCalendar("2025-08-29")
+            }
+
+            verify(exactly = 1) { petFairQueryDSLRepository.petFairCalendar(any()) }
+
+            val errorCode = exception.errorCode
+            errorCode.message() shouldBe "펫페어 행사가 없습니다."
+            errorCode.httpStatus() shouldBe HttpStatus.NOT_FOUND
+            errorCode.code() shouldBe "NOT_FOUND_PET_FAIR_CALENDAR"
+        }
+    }
+
+    beforeTest {
+        petFairQueryService = mockk(relaxed = true)
+        petFairQueryDSLRepository = mockk(relaxed = true)
+
+        petFairQueryService = PetFairQueryService(petFairQueryDSLRepository)
+    }
+})


### PR DESCRIPTION
## 개요
- Petfair 관련 **조회 비즈니스 로직** 구현
- **Password 수정 로직** 구현

## 작업 목록
- [x] Password 수정 API 로직 구현 (validation, 암호화 포함)
- [x] Main 페이지 Carousel API 로직 구현
- [x] Calendar API 로직 구현

## Test
- Command/Query 분리 구조에 따라 단위 테스트 진행 예정
- 주요 테스트 케이스:
  - [x] Password 수정 성공/실패 케이스
  - [x] Carousel 데이터 정상 조회/ 실패 케이스
  - [x] Calendar 조회/실패 케이스

## 추가 내용
- Password 는 PasswordEditRequest 를 영문, 숫자 특수문자 포함하여 8글자 이상 데이터를 검증하도록 패턴 생성
- 테스트 코드는 FreeSpec을 사용하여 구현