### PR TITLE
Feature/petfair create delete

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,13 @@ dependencies {
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 
+    // webp 변환
+    implementation("com.sksamuel.scrimage:scrimage-core:4.3.4")
+    implementation("com.sksamuel.scrimage:scrimage-webp:4.3.4")
+
+    //사진 업로드
+    implementation("software.amazon.awssdk:s3:2.25.46")
+
     //test
     testImplementation("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/java/com/example/pawgetherbe/common/exceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/pawgetherbe/common/exceptionHandler/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -44,5 +45,15 @@ public final class GlobalExceptionHandler {
                 .build();
 
         return ResponseEntity.badRequest().body(responseBody);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponseDto> handleMaxUploadSize(MaxUploadSizeExceededException ex) {
+        var body = ErrorResponseDto.builder()
+                .status(HttpStatus.PAYLOAD_TOO_LARGE.value())
+                .code("FILE_TOO_LARGE")
+                .message("업로드 가능한 파일 용량을 초과했습니다.")
+                .build();
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(body);
     }
 }

--- a/src/main/java/com/example/pawgetherbe/config/MultipartConfig.java
+++ b/src/main/java/com/example/pawgetherbe/config/MultipartConfig.java
@@ -1,0 +1,19 @@
+package com.example.pawgetherbe.config;
+
+import jakarta.servlet.MultipartConfigElement;
+import org.springframework.boot.web.servlet.MultipartConfigFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.unit.DataSize;
+
+@Configuration
+public class MultipartConfig {
+
+    @Bean
+    public MultipartConfigElement multipartConfigElement() {
+        MultipartConfigFactory factory = new MultipartConfigFactory();
+        factory.setMaxFileSize(DataSize.parse("10MB"));
+        factory.setMaxRequestSize(DataSize.parse("70MB"));
+        return factory.createMultipartConfig();
+    }
+}

--- a/src/main/java/com/example/pawgetherbe/config/R2Config.java
+++ b/src/main/java/com/example/pawgetherbe/config/R2Config.java
@@ -1,0 +1,43 @@
+package com.example.pawgetherbe.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+import java.net.URI;
+
+@Configuration
+public class R2Config {
+    @Value("${cloudflare.r2.endpoint}")
+    private String endpoint;
+
+    @Value("${cloudflare.r2.access-key}")
+    private String accessKey;
+
+    @Value("${cloudflare.r2.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public S3Client r2Client() {
+        return S3Client.builder()
+                .region(Region.of("auto")) // R2는 region 고정
+                .endpointOverride(URI.create(endpoint))
+                .serviceConfiguration(
+                        S3Configuration.builder()
+                                // 버킷-서브도메인 방식 사용(권장)
+                                .pathStyleAccessEnabled(false)
+                                .build()
+                )
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey.trim(), secretKey.trim())
+                        )
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/example/pawgetherbe/config/TomcatConfig.java
+++ b/src/main/java/com/example/pawgetherbe/config/TomcatConfig.java
@@ -1,0 +1,18 @@
+package com.example.pawgetherbe.config;
+
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TomcatConfig {
+    @Bean
+    public WebServerFactoryCustomizer<TomcatServletWebServerFactory> multipartConfigCustomizer() {
+        return factory -> {
+            factory.addConnectorCustomizers(connector -> {
+                connector.setMaxPartCount(30);
+            });
+        };
+    }
+}

--- a/src/main/java/com/example/pawgetherbe/controller/command/PetFairCommandApi.java
+++ b/src/main/java/com/example/pawgetherbe/controller/command/PetFairCommandApi.java
@@ -1,27 +1,40 @@
 package com.example.pawgetherbe.controller.command;
 
-import com.example.pawgetherbe.controller.command.dto.PetFairCommandDto.PetFairCreateResponse;
 import com.example.pawgetherbe.controller.command.dto.PetFairCommandDto.PetFairCreateRequest;
+import com.example.pawgetherbe.controller.command.dto.PetFairCommandDto.PetFairCreateResponse;
+import com.example.pawgetherbe.usecase.post.DeletePostUseCase;
 import com.example.pawgetherbe.usecase.post.RegistryPostUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/petfair")
+@RequestMapping("/api/v1/petfairs")
 @RequiredArgsConstructor
 @Slf4j
 public class PetFairCommandApi {
 
     private final RegistryPostUseCase registryPostUseCase;
+    private final DeletePostUseCase deletePostUseCase;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @ResponseStatus(HttpStatus.OK)
     public PetFairCreateResponse PetFairPostCreate(@Valid @ModelAttribute PetFairCreateRequest petFairCreateRequest) {
         return registryPostUseCase.postCreate(petFairCreateRequest);
+    }
+
+    @DeleteMapping("/{petfairId}")
+    @ResponseStatus(HttpStatus.OK)
+    public void PetFairPostDelete(@PathVariable long petfairId) {
+        deletePostUseCase.deletePost(petfairId);
     }
 }

--- a/src/main/java/com/example/pawgetherbe/controller/command/PetFairCommandApi.java
+++ b/src/main/java/com/example/pawgetherbe/controller/command/PetFairCommandApi.java
@@ -1,0 +1,27 @@
+package com.example.pawgetherbe.controller.command;
+
+import com.example.pawgetherbe.controller.command.dto.PetFairCommandDto.PetFairCreateResponse;
+import com.example.pawgetherbe.controller.command.dto.PetFairCommandDto.PetFairCreateRequest;
+import com.example.pawgetherbe.usecase.post.RegistryPostUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/petfair")
+@RequiredArgsConstructor
+@Slf4j
+public class PetFairCommandApi {
+
+    private final RegistryPostUseCase registryPostUseCase;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public PetFairCreateResponse PetFairPostCreate(@Valid @ModelAttribute PetFairCreateRequest petFairCreateRequest) {
+        return registryPostUseCase.postCreate(petFairCreateRequest);
+    }
+}

--- a/src/main/java/com/example/pawgetherbe/controller/command/dto/PetFairCommandDto.java
+++ b/src/main/java/com/example/pawgetherbe/controller/command/dto/PetFairCommandDto.java
@@ -1,0 +1,73 @@
+package com.example.pawgetherbe.controller.command.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public final class PetFairCommandDto {
+
+    public record PetFairCreateRequest(
+            @NotBlank(message = "제목을 입력해 주세요")
+            String title,
+
+            @NotBlank(message = "내용을 입력해 주세요")
+            String content,
+
+            @NotNull(message = "PosterImage 를 첨부해 주세요")
+            MultipartFile posterImage,
+
+            @NotBlank(message = "simpleAddress 를 입력해 주세요")
+            String simpleAddress,
+
+            @NotBlank(message = "detailAddress 를 입력해 주세요")
+            String detailAddress,
+
+            @NotBlank(message = "시작날짜를 입력해 주세요")
+            String startDate,
+
+            @NotBlank(message = "종료날짜를 입력해 주세요")
+            String endDate,
+
+            @NotBlank(message = "행사 회사 번호를 입력해 주세요")
+            String telNumber,
+
+            @NotBlank(message = "행사 링크를 입력해 주세요")
+            String petFairUrl,
+
+            @NotNull(message = "image 를 첨부해 주세요")
+            @Size(max = 5, message = "image 는 최대 5개까지 첨부가능합니다.")
+            List<MultipartFile> images
+    ) {
+        @AssertTrue(message = "PosterImage 를 첨부해 주세요")
+        public boolean isPosterImageNotEmpty() {
+            return posterImage != null && !posterImage.isEmpty();
+        }
+
+        @AssertTrue(message = "비어있는 image 파일이 있습니다")
+        public boolean isImagesAllNonEmpty() {
+            return images != null && !images.isEmpty()
+                    && images.stream().allMatch(f -> f != null && !f.isEmpty());
+        }
+    }
+
+    public record PetFairCreateResponse(
+            Long petFairId,
+            String title,
+            String content,
+            String posterImageUrl,
+            String petFairUrl,
+            String simpleAddress,
+            String detailAddress,
+            String startDate,
+            String endDate,
+            String telNumber,
+            List<String> images,
+            Long counter,
+            String createdAt,
+            String updatedAt
+    ) {}
+}

--- a/src/main/java/com/example/pawgetherbe/domain/entity/PetFairEntity.java
+++ b/src/main/java/com/example/pawgetherbe/domain/entity/PetFairEntity.java
@@ -60,9 +60,9 @@ public class PetFairEntity extends BaseEntity {
     @Column(name = "pet_fair_url")
     private String petFairUrl;
 
-    @Lob
-    @Column(name = "map_url")
-    private String mapUrl;
+//    @Lob
+//    @Column(name = "map_url")
+//    private String mapUrl;
 
     @Lob
     @Column(name = "content")
@@ -71,11 +71,11 @@ public class PetFairEntity extends BaseEntity {
     @Column(name = "counter")
     private Long counter;
 
-    @Column(name = "latitude", length = 255)
-    private String latitude;
-
-    @Column(name = "longitude", length = 255)
-    private String longitude;
+//    @Column(name = "latitude", length = 255)
+//    private String latitude;
+//
+//    @Column(name = "longitude", length = 255)
+//    private String longitude;
 
     @Column(name = "tel_number", length = 255)
     private String telNumber;
@@ -97,6 +97,18 @@ public class PetFairEntity extends BaseEntity {
 
     @OneToMany(mappedBy="petFair", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<BookmarkEntity> bookmarkEntities = new ArrayList<>();
+
+    public void updateImage(String posterImageUrl, List<PetFairImageEntity> pairImages,
+                            PetFairStatus status, UserEntity user) {
+        this.posterImageUrl = posterImageUrl;
+        this.status = status;
+        this.user = user;
+
+        this.pairImages.clear();
+        for (PetFairImageEntity img : pairImages) {
+            this.addImage(img);
+        }
+    }
 
     public void addImage(PetFairImageEntity image) {
         pairImages.add(image);

--- a/src/main/java/com/example/pawgetherbe/domain/entity/PetFairEntity.java
+++ b/src/main/java/com/example/pawgetherbe/domain/entity/PetFairEntity.java
@@ -114,4 +114,8 @@ public class PetFairEntity extends BaseEntity {
         pairImages.add(image);
         image.setPetFair(this);
     }
+
+    public void updateStatus(PetFairStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/example/pawgetherbe/domain/entity/PetFairImageEntity.java
+++ b/src/main/java/com/example/pawgetherbe/domain/entity/PetFairImageEntity.java
@@ -38,4 +38,8 @@ public class PetFairImageEntity extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pet_fair_id", nullable = false)
     private PetFairEntity petFair;
+
+    void setPetFair(PetFairEntity petFair) {
+        this.petFair = petFair;
+    }
 }

--- a/src/main/java/com/example/pawgetherbe/exception/command/PetFairCommandErrorCode.java
+++ b/src/main/java/com/example/pawgetherbe/exception/command/PetFairCommandErrorCode.java
@@ -1,0 +1,36 @@
+package com.example.pawgetherbe.exception.command;
+
+import com.example.pawgetherbe.common.exceptionHandler.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum PetFairCommandErrorCode implements ErrorCode {
+    PET_FAIR_CREATE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "CREATE_FAIL", "펫페어 생성 실패"),
+    IMAGE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_CONVERT_FAIL", "이미지를 webp로 변환하는 중 오류가 발생했습니다."),
+
+    ;
+
+    private final String message;
+    private final String code;
+    private final HttpStatus httpStatus;
+
+    PetFairCommandErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.message = message;
+        this.code = code;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/example/pawgetherbe/exception/command/PetFairCommandErrorCode.java
+++ b/src/main/java/com/example/pawgetherbe/exception/command/PetFairCommandErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum PetFairCommandErrorCode implements ErrorCode {
     PET_FAIR_CREATE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "CREATE_FAIL", "펫페어 생성 실패"),
     IMAGE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_CONVERT_FAIL", "이미지를 webp로 변환하는 중 오류가 발생했습니다."),
-
+    REMOVED_PET_FAIR(HttpStatus.CONFLICT, "REMOVED_PET_FAIR", "이미 삭제된 게시글입니다."),
+    NOT_FOUND_PET_FAIR(HttpStatus.NOT_FOUND, "NOT_FOUND_PET_FAIR", "해당 펫페어가 없습니다."),
     ;
 
     private final String message;

--- a/src/main/java/com/example/pawgetherbe/mapper/command/PetFairCommandMapper.java
+++ b/src/main/java/com/example/pawgetherbe/mapper/command/PetFairCommandMapper.java
@@ -1,4 +1,25 @@
 package com.example.pawgetherbe.mapper.command;
 
+import com.example.pawgetherbe.controller.command.dto.PetFairCommandDto.PetFairCreateRequest;
+import com.example.pawgetherbe.controller.command.dto.PetFairCommandDto.PetFairCreateResponse;
+import com.example.pawgetherbe.domain.entity.PetFairEntity;
+import com.example.pawgetherbe.domain.entity.PetFairImageEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper
 public interface PetFairCommandMapper {
+    PetFairEntity toPetFairEntity(PetFairCreateRequest petFairCreateRequest);
+
+    @Mapping(target = "images", source = "pairImages")
+    PetFairCreateResponse toPetFairCreateResponse(PetFairEntity petFairEntity);
+
+    default List<String> mapImages(List<PetFairImageEntity> imageEntities) {
+        if (imageEntities == null) return List.of();
+        return imageEntities.stream()
+                .map(PetFairImageEntity::getImageUrl)
+                .toList();
+    }
 }

--- a/src/main/java/com/example/pawgetherbe/mapper/command/PetFairCommandMapper.java
+++ b/src/main/java/com/example/pawgetherbe/mapper/command/PetFairCommandMapper.java
@@ -13,6 +13,7 @@ import java.util.List;
 public interface PetFairCommandMapper {
     PetFairEntity toPetFairEntity(PetFairCreateRequest petFairCreateRequest);
 
+    @Mapping(target = "petFairId", source = "id")
     @Mapping(target = "images", source = "pairImages")
     PetFairCreateResponse toPetFairCreateResponse(PetFairEntity petFairEntity);
 

--- a/src/main/java/com/example/pawgetherbe/repository/command/PetFairCommandRepository.java
+++ b/src/main/java/com/example/pawgetherbe/repository/command/PetFairCommandRepository.java
@@ -1,0 +1,7 @@
+package com.example.pawgetherbe.repository.command;
+
+import com.example.pawgetherbe.domain.entity.PetFairEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PetFairCommandRepository extends JpaRepository<PetFairEntity, Long> {
+}

--- a/src/main/java/com/example/pawgetherbe/repository/command/PetFairImageCommandRepository.java
+++ b/src/main/java/com/example/pawgetherbe/repository/command/PetFairImageCommandRepository.java
@@ -1,0 +1,7 @@
+package com.example.pawgetherbe.repository.command;
+
+import com.example.pawgetherbe.domain.entity.PetFairImageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PetFairImageCommandRepository extends JpaRepository<PetFairImageEntity, Long> {
+}

--- a/src/main/java/com/example/pawgetherbe/service/command/PetFairCommandService.java
+++ b/src/main/java/com/example/pawgetherbe/service/command/PetFairCommandService.java
@@ -1,0 +1,137 @@
+package com.example.pawgetherbe.service.command;
+
+import com.example.pawgetherbe.common.exceptionHandler.CustomException;
+import com.example.pawgetherbe.controller.command.dto.PetFairCommandDto.PetFairCreateRequest;
+import com.example.pawgetherbe.controller.command.dto.PetFairCommandDto.PetFairCreateResponse;
+import com.example.pawgetherbe.domain.entity.PetFairImageEntity;
+import com.example.pawgetherbe.domain.status.PetFairStatus;
+import com.example.pawgetherbe.mapper.command.PetFairCommandMapper;
+import com.example.pawgetherbe.repository.command.PetFairCommandRepository;
+import com.example.pawgetherbe.repository.command.UserCommandRepository;
+import com.example.pawgetherbe.usecase.post.RegistryPostUseCase;
+import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.webp.WebpWriter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executors;
+
+import static com.example.pawgetherbe.exception.command.UserCommandErrorCode.NOT_FOUND_USER;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PetFairCommandService implements RegistryPostUseCase {
+
+    private final PetFairCommandRepository petFairCommandRepository;
+    private final UserCommandRepository userCommandRepository;
+    private final PetFairCommandMapper petFairCommandMapper;
+
+    private final S3Client r2Client;
+
+    private final String bucketName = "pawgether-public";
+
+    @Override
+    @Transactional
+    public PetFairCreateResponse postCreate(PetFairCreateRequest req) {
+//        var id = Long.valueOf(getUserId());
+        var id = 1L;
+        var user = userCommandRepository.findById(id).orElseThrow(() -> new CustomException(NOT_FOUND_USER));
+
+        try {
+            var date = LocalDate.parse(req.startDate());
+            List<PetFairImageEntity> petFairImageEntities = new ArrayList<>();
+
+            String baseName = String.format("%02d%02d", date.getMonthValue(), date.getDayOfMonth());
+
+            // 포스터 이미지 업로드
+            String posterKey = String.format("poster/%d/%02d/%s.webp",
+                    date.getYear(), date.getMonthValue(), baseName);
+            byte[] posterBytes = toWebp(req.posterImage());
+//            uploadToR2(posterKey, posterBytes);
+
+            // 추가 이미지 업로드 (parallel 변환)
+            List<byte[]> images = toWebpsParallel(req.images());
+            for (int i = 0; i < images.size(); i++) {
+                String key = String.format("images/%d/%02d/%s-%d.webp",
+                        date.getYear(), date.getMonthValue(), baseName, (i + 1));
+
+                var builder = PetFairImageEntity.builder()
+                        .imageUrl(key)
+                        .sortOrder((i + 1))
+                        .build();
+
+                petFairImageEntities.add(builder);
+//                uploadToR2(key, images.get(i));
+            }
+
+            var PetFairEntity = petFairCommandMapper.toPetFairEntity(req);
+
+            PetFairEntity.updateImage(posterKey, petFairImageEntities, PetFairStatus.ACTIVE, user);
+
+            var petFair = petFairCommandRepository.save(PetFairEntity);
+            return petFairCommandMapper.toPetFairCreateResponse(petFair);
+
+        } catch (Exception e) {
+            throw new RuntimeException("펫페어 생성 실패", e);
+        }
+    }
+
+    private void uploadToR2(String key, byte[] data) {
+        r2Client.putObject(
+                PutObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(key)
+                        .contentType("image/webp")
+                        .build(),
+                RequestBody.fromBytes(data)
+        );
+        log.info("업로드 완료: {}", key);
+    }
+
+    private byte[] toWebp(MultipartFile file) throws Exception {
+        // 이미 webp면 그대로 통과
+        String name = file.getOriginalFilename() == null ? "" : file.getOriginalFilename().toLowerCase();
+        String ct = file.getContentType() == null ? "" : file.getContentType().toLowerCase();
+        if (ct.equals("image/webp") || name.endsWith(".webp")) {
+            return file.getBytes();
+        }
+
+        ImmutableImage img = ImmutableImage.loader().fromStream(file.getInputStream());
+
+        return img.bytes(WebpWriter.DEFAULT);
+    }
+
+    private List<byte[]> toWebpsParallel(List<MultipartFile> files) {
+        // 빈 입력 방어: null 또는 빈 리스트면 즉시 빈 리스트 반환
+        if (files == null || files.isEmpty()) return List.of();
+
+        // 작업당 가상 스레드를 생성하는 Executor. 각 파일 변환을 독립적으로 수행.
+        try (var exec = Executors.newVirtualThreadPerTaskExecutor()) {
+
+            return files.stream()
+                    .map(f -> CompletableFuture.supplyAsync(() -> {
+                                try {
+                                    return toWebp(f);
+                                } catch (Exception e) {
+                                    throw new CompletionException(e);
+                                }
+                            }, exec)
+                    )
+                    // 모든 Future를 순서대로 join하여 결과 수집(입력 순서 유지)
+                    .map(CompletableFuture::join)
+                    .toList();
+        }
+    }
+}

--- a/src/main/java/com/example/pawgetherbe/usecase/post/DeletePostUseCase.java
+++ b/src/main/java/com/example/pawgetherbe/usecase/post/DeletePostUseCase.java
@@ -1,4 +1,5 @@
 package com.example.pawgetherbe.usecase.post;
 
 public interface DeletePostUseCase {
+    void deletePost(long postId);
 }

--- a/src/main/java/com/example/pawgetherbe/usecase/post/RegistryPostUseCase.java
+++ b/src/main/java/com/example/pawgetherbe/usecase/post/RegistryPostUseCase.java
@@ -1,4 +1,8 @@
 package com.example.pawgetherbe.usecase.post;
 
+import com.example.pawgetherbe.controller.command.dto.PetFairCommandDto.PetFairCreateResponse;
+import com.example.pawgetherbe.controller.command.dto.PetFairCommandDto.PetFairCreateRequest;
+
 public interface RegistryPostUseCase {
+    PetFairCreateResponse postCreate(PetFairCreateRequest petFairCommandDto);
 }

--- a/src/test/kotlin/com/example/pawgetherbe/account/PetFairCommandApiTest.kt
+++ b/src/test/kotlin/com/example/pawgetherbe/account/PetFairCommandApiTest.kt
@@ -1,0 +1,155 @@
+package com.example.pawgetherbe.account
+
+import com.example.pawgetherbe.common.exceptionHandler.CustomException
+import com.example.pawgetherbe.common.exceptionHandler.GlobalExceptionHandler
+import com.example.pawgetherbe.controller.command.PetFairCommandApi
+import com.example.pawgetherbe.controller.command.dto.PetFairCommandDto
+import com.example.pawgetherbe.domain.UserContext
+import com.example.pawgetherbe.exception.command.PetFairCommandErrorCode.IMAGE_CONVERT_FAIL
+import com.example.pawgetherbe.exception.command.PetFairCommandErrorCode.PET_FAIR_CREATE_FAIL
+import com.example.pawgetherbe.exception.command.PetFairCommandErrorCode.REMOVED_PET_FAIR
+import com.example.pawgetherbe.usecase.post.DeletePostUseCase
+import com.example.pawgetherbe.usecase.post.RegistryPostUseCase
+import io.kotest.core.spec.style.FreeSpec
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@ActiveProfiles("test")
+class PetFairCommandApiTest: FreeSpec({
+    lateinit var mockMvc: MockMvc
+    lateinit var petFairApi: PetFairCommandApi
+    lateinit var registryPostUseCase: RegistryPostUseCase
+    lateinit var deletePostUseCase : DeletePostUseCase
+
+    beforeTest {
+        mockkStatic(UserContext::class)
+        every { UserContext.getUserId() } returns "1"
+
+        registryPostUseCase = mockk()
+        deletePostUseCase = mockk()
+
+        petFairApi = PetFairCommandApi(registryPostUseCase, deletePostUseCase)
+
+        mockMvc = MockMvcBuilders.standaloneSetup(petFairApi)
+            .setControllerAdvice(GlobalExceptionHandler())
+            .build()
+    }
+
+    "PetFairPostCreate" - {
+        val poster = MockMultipartFile(
+            "posterImage", "poster.webp", "image/webp", "poster-bytes".toByteArray()
+        )
+        val img1 = MockMultipartFile("images", "a.webp", "image/webp", "i1".toByteArray())
+        val img2 = MockMultipartFile("images", "b.webp", "image/webp", "i2".toByteArray())
+
+        val form = multipart("/api/v1/petfairs")
+            .file("posterImage", poster.bytes)
+            .file("images", img1.bytes)
+            .file("images", img2.bytes)
+            .param("title", "제목")
+            .param("content", "내용")
+            .param("simpleAddress", "서울시")
+            .param("detailAddress", "강남구")
+            .param("startDate", "2025-09-04")
+            .param("endDate", "2025-09-05")
+            .param("telNumber", "02-123-4567")
+            .param("petFairUrl", "https://example.com")
+            .characterEncoding("UTF-8")
+
+        "생성 성공" {
+            val resp = PetFairCommandDto.PetFairCreateResponse(
+                1L,
+                "제목",
+                "내용",
+                "poster/2025/09/0904.webp",
+                "https://example.com",
+                "강남구",
+                "서울시 강남구",
+                "2025-09-04",
+                "2025-09-05",
+                "02-123-4567",
+                listOf("images/2025/09/0904-1.webp", "images/2025/09/0904-2.webp"),
+                0L,
+                "2025-09-05",
+                "2025-09-05"
+
+            )
+            every { registryPostUseCase.postCreate(any<PetFairCommandDto.PetFairCreateRequest>()) } returns resp
+
+            // when + then
+            mockMvc.perform(form)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.petFairId").value(1))
+                .andExpect(jsonPath("$.posterImageUrl").value("poster/2025/09/0904.webp"))
+                .andExpect(jsonPath("$.images[0]").value("images/2025/09/0904-1.webp"))
+
+            verify(exactly = 1) { registryPostUseCase.postCreate(any()) }
+        }
+
+        "이미지 변환 실패" {
+            every { registryPostUseCase.postCreate(any<PetFairCommandDto.PetFairCreateRequest>()) } throws CustomException(
+                IMAGE_CONVERT_FAIL
+            )
+
+            mockMvc.perform(form)
+                .andExpect(status().is5xxServerError)
+                .andExpect(jsonPath("$.code").value("IMAGE_CONVERT_FAIL"))
+                .andExpect(jsonPath("$.status").value(HttpStatus.INTERNAL_SERVER_ERROR.value()))
+                .andExpect(jsonPath("$.message").value("이미지를 webp로 변환하는 중 오류가 발생했습니다."))
+
+            verify(exactly = 1) { registryPostUseCase.postCreate(any()) }
+        }
+
+        "생성 실패" {
+            every { registryPostUseCase.postCreate(any<PetFairCommandDto.PetFairCreateRequest>()) } throws CustomException(
+                PET_FAIR_CREATE_FAIL
+            )
+
+            mockMvc.perform(form)
+                .andExpect(status().is5xxServerError)
+                .andExpect(jsonPath("$.code").value("CREATE_FAIL"))
+                .andExpect(jsonPath("$.status").value(HttpStatus.INTERNAL_SERVER_ERROR.value()))
+                .andExpect(jsonPath("$.message").value("펫페어 생성 실패"))
+
+            verify(exactly = 1) { registryPostUseCase.postCreate(any()) }
+        }
+    }
+
+    "PetFairPostDelete" - {
+        "삭제 성공" {
+            every { deletePostUseCase.deletePost(1L) } just Runs
+
+            mockMvc.perform(delete("/api/v1/petfairs/{petfairId}", 1L))
+                .andExpect(status().isOk)
+
+            verify(exactly = 1) { deletePostUseCase.deletePost(1L) }
+        }
+
+        "삭제 실패" {
+            every { deletePostUseCase.deletePost(1L) } throws CustomException(
+                REMOVED_PET_FAIR
+            )
+
+            mockMvc.perform(delete("/api/v1/petfairs/{petfairId}", 1L))
+                .andExpect(status().is4xxClientError)
+                .andExpect(jsonPath("$.code").value("REMOVED_PET_FAIR"))
+                .andExpect(jsonPath("$.status").value(HttpStatus.CONFLICT.value()))
+                .andExpect(jsonPath("$.message").value("이미 삭제된 게시글입니다."))
+
+            verify(exactly = 1) { deletePostUseCase.deletePost(1L) }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/pawgetherbe/account/PetFairCommandApiTest.kt
+++ b/src/test/kotlin/com/example/pawgetherbe/account/PetFairCommandApiTest.kt
@@ -16,6 +16,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.springframework.http.HttpStatus
 import org.springframework.mock.web.MockMultipartFile
@@ -46,6 +47,10 @@ class PetFairCommandApiTest: FreeSpec({
         mockMvc = MockMvcBuilders.standaloneSetup(petFairApi)
             .setControllerAdvice(GlobalExceptionHandler())
             .build()
+    }
+
+    afterTest {
+        unmockkStatic(UserContext::class)
     }
 
     "PetFairPostCreate" - {

--- a/src/test/kotlin/com/example/pawgetherbe/account/PetFairCommandServiceTest.kt
+++ b/src/test/kotlin/com/example/pawgetherbe/account/PetFairCommandServiceTest.kt
@@ -1,0 +1,188 @@
+package com.example.pawgetherbe.account
+
+import com.example.pawgetherbe.common.exceptionHandler.CustomException
+import com.example.pawgetherbe.controller.command.dto.PetFairCommandDto
+import com.example.pawgetherbe.domain.UserContext
+import com.example.pawgetherbe.domain.entity.PetFairEntity
+import com.example.pawgetherbe.domain.entity.PetFairImageEntity
+import com.example.pawgetherbe.domain.entity.UserEntity
+import com.example.pawgetherbe.domain.status.PetFairStatus
+import com.example.pawgetherbe.exception.command.PetFairCommandErrorCode.IMAGE_CONVERT_FAIL
+import com.example.pawgetherbe.exception.command.PetFairCommandErrorCode.PET_FAIR_CREATE_FAIL
+import com.example.pawgetherbe.exception.command.PetFairCommandErrorCode.REMOVED_PET_FAIR
+import com.example.pawgetherbe.mapper.command.PetFairCommandMapper
+import com.example.pawgetherbe.repository.command.PetFairCommandRepository
+import com.example.pawgetherbe.repository.command.UserCommandRepository
+import com.example.pawgetherbe.service.command.PetFairCommandService
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.web.multipart.MultipartFile
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import java.io.IOException
+import java.util.*
+
+
+@ActiveProfiles("test")
+@ExtendWith(SpringExtension::class)
+class PetFairCommandServiceTest: FreeSpec({
+
+    lateinit var petFairCommandService: PetFairCommandService
+    lateinit var userCommandRepository: UserCommandRepository
+    lateinit var petFairCommandMapper: PetFairCommandMapper
+    lateinit var petFairCommandRepository: PetFairCommandRepository
+    lateinit var r2Client: S3Client
+
+    lateinit var req: PetFairCommandDto.PetFairCreateRequest
+    lateinit var user: UserEntity
+    lateinit var entity: PetFairEntity
+
+    fun webp(name: String, bytes: String) = mockk<MultipartFile>().also {
+        every { it.originalFilename } returns name
+        every { it.contentType } returns "image/webp"
+        every { it.bytes } returns bytes.toByteArray()
+    }
+
+    fun brokenJpeg(name: String = "poster.jpg"): MultipartFile = mockk {
+        every { originalFilename } returns name
+        every { contentType } returns "image/jpeg"
+        every { inputStream } throws IOException("boom")
+    }
+
+    "PetFairPostCreate" - {
+        "post 생성 성공" {
+            // given
+            every { req.posterImage() } returns webp("poster.webp", "poster")
+            every { req.images() } returns listOf(webp("a.webp", "i1"), webp("b.webp", "i2"))
+            every { petFairCommandRepository.save(entity) } returns entity
+
+            val resp = mockk<PetFairCommandDto.PetFairCreateResponse>()
+            every { petFairCommandMapper.toPetFairCreateResponse(entity) } returns resp
+
+            // when
+            val result = petFairCommandService.postCreate(req)
+
+            // then
+            result shouldBe resp
+
+            verify(exactly = 1) {
+                r2Client.putObject(
+                    match<PutObjectRequest> { it.key() == "poster/2025/09/0904.webp" },
+                    any<RequestBody>()
+                )
+            }
+            verify(exactly = 1) {
+                r2Client.putObject(
+                    match<PutObjectRequest> { it.key() == "images/2025/09/0904-1.webp" },
+                    any<RequestBody>()
+                )
+            }
+            verify(exactly = 1) {
+                r2Client.putObject(
+                    match<PutObjectRequest> { it.key() == "images/2025/09/0904-2.webp" },
+                    any<RequestBody>()
+                )
+            }
+            verify(exactly = 1) {
+                entity.updateImage(
+                    "poster/2025/09/0904.webp",
+                    withArg<List<PetFairImageEntity>> { it.size shouldBe 2 },
+                    PetFairStatus.ACTIVE,
+                    user
+                )
+            }
+            verify(exactly = 1) { petFairCommandRepository.save(entity) }
+        }
+
+        ".webp 변환 실패" {
+            // given
+            every { req.posterImage() } returns brokenJpeg()
+
+            // when
+            val exception = shouldThrow<CustomException> { petFairCommandService.postCreate(req) }
+
+            // then
+            exception.errorCode shouldBe IMAGE_CONVERT_FAIL
+
+            verify(exactly = 0) { r2Client.putObject(any<PutObjectRequest>(), any<RequestBody>()) }
+            verify(exactly = 0) { petFairCommandRepository.save(any()) }
+        }
+
+        "post 생성 실패" {
+            // given
+            every { req.posterImage() } returns webp("poster.webp", "poster")
+            every { req.images() } returns listOf(webp("a.webp", "i1"), webp("b.webp", "i2"))
+            every { petFairCommandRepository.save(entity) } throws RuntimeException("DB down")
+
+            // when
+            val exception = shouldThrow<CustomException> { petFairCommandService.postCreate(req) }
+
+            // then
+            exception.errorCode shouldBe PET_FAIR_CREATE_FAIL
+
+            verify(atLeast = 2) { r2Client.putObject(any<PutObjectRequest>(), any<RequestBody>()) }
+        }
+    }
+
+    "deletePost" - {
+        "Post 정상 삭제" {
+            // given
+            every { entity.status } returns PetFairStatus.ACTIVE
+            every { petFairCommandRepository.findById(1L) } returns Optional.of(entity)
+
+            // when
+            petFairCommandService.deletePost(1L)
+
+            // then
+            verify(exactly = 1) { entity.updateStatus(PetFairStatus.REMOVED) }
+        }
+
+        "Post 삭제 실패" {
+            // given
+            every { entity.status } returns PetFairStatus.REMOVED
+            every { petFairCommandRepository.findById(1L) } returns Optional.of(entity)
+
+            // when
+            val exception = shouldThrow<CustomException> { petFairCommandService.deletePost(1L) }
+
+            // then
+            exception.errorCode shouldBe REMOVED_PET_FAIR
+            verify(exactly = 0) { entity.updateStatus(PetFairStatus.REMOVED) }
+        }
+    }
+
+    beforeTest {
+        mockkStatic(UserContext::class)
+
+        user = mockk()
+        req = mockk(relaxed = true)
+        entity = mockk(relaxed = true)
+        petFairCommandService = mockk(relaxed = true)
+        userCommandRepository = mockk(relaxed = true)
+        petFairCommandMapper = mockk(relaxed = true)
+        petFairCommandRepository = mockk(relaxed = true)
+        r2Client = mockk(relaxed = true)
+
+        every { UserContext.getUserId() } returns "1"
+        every { userCommandRepository.findById(1L) } returns Optional.of(user)
+        every { petFairCommandMapper.toPetFairEntity(req) } returns entity
+        every { req.startDate() } returns "2025-09-04"
+        every { req.images() } returns emptyList()
+
+        petFairCommandService = PetFairCommandService(
+            petFairCommandRepository,
+            userCommandRepository,
+            petFairCommandMapper,
+            r2Client
+        )
+    }
+})

--- a/src/test/kotlin/com/example/pawgetherbe/account/PetFairCommandServiceTest.kt
+++ b/src/test/kotlin/com/example/pawgetherbe/account/PetFairCommandServiceTest.kt
@@ -20,6 +20,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.test.context.ActiveProfiles
@@ -184,5 +185,9 @@ class PetFairCommandServiceTest: FreeSpec({
             petFairCommandMapper,
             r2Client
         )
+    }
+
+    afterTest {
+        unmockkStatic(UserContext::class)
     }
 })


### PR DESCRIPTION
## 개요
- Petfair **생성** 및 **삭제** 로직 구현

## 작업 목록
- [x] Petfair 생성 API 로직 구현 (.webp 변환 및 가상스레드 사용, 클라우드 사진 업로드)
- [x] Petfair 삭제 API 로직 구현 (soft delete)

## Test
- Command/Query 분리 구조에 따라 단위 테스트 진행 예정
- 주요 테스트 케이스:
  - [x] Petfair 생성 성공/실패 케이스
  - [x] Petfair 삭제 성공/실패 케이스

## 추가 내용
- cloudflare 사용하여 사진 업로드 
- sksamuel 사용하여 이미지 변환