### PR TITLE
Fix/bookmark

### DIFF
--- a/src/main/java/com/example/pawgetherbe/controller/command/dto/BookmarkCommandDto.java
+++ b/src/main/java/com/example/pawgetherbe/controller/command/dto/BookmarkCommandDto.java
@@ -2,6 +2,7 @@ package com.example.pawgetherbe.controller.command.dto;
 
 public final class BookmarkCommandDto {
     public record BookmarkResponse(
-            boolean isBookmark
+            long targetId,
+            boolean isBookmarked
     ) {}
 }

--- a/src/main/java/com/example/pawgetherbe/controller/query/BookmarkQueryApi.java
+++ b/src/main/java/com/example/pawgetherbe/controller/query/BookmarkQueryApi.java
@@ -18,8 +18,8 @@ public class BookmarkQueryApi {
     private final IsBookmarkedUseCase isBookmarkedUseCase;
 
     @GetMapping
-    public SummaryBookmarksResponse readBookmarks() {
-        return readBookmarksUseCase.readBookmarks();
+    public SummaryBookmarksResponse readBookmarkList(@RequestParam(required = false) Long cursor) {
+        return readBookmarksUseCase.readBookmarkList(cursor);
     }
 
     @GetMapping("/exists")

--- a/src/main/java/com/example/pawgetherbe/controller/query/dto/BookmarkQueryDto.java
+++ b/src/main/java/com/example/pawgetherbe/controller/query/dto/BookmarkQueryDto.java
@@ -1,24 +1,17 @@
 package com.example.pawgetherbe.controller.query.dto;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public final class BookmarkQueryDto {
     public record SummaryBookmarksResponse(
             boolean hasMore,
-            Long nextCursor,
-            List<DetailBookmarkedPetFairResponse> petFairResponses
+            long nextCursor,
+            List<TargetResponse> bookmarkResponseList
     ) {}
 
-    public record DetailBookmarkedPetFairResponse(
-            Long petFairId,
-            Long counter,
-            String title,
-            String posterImageUrl,
-            LocalDate startDate,
-            LocalDate endDate,
-            String simpleAddress,
-            boolean isBookmark
+    public record ReadBookmarkListResponse(
+            long bookmarkId,
+            long petFairId
     ) {}
 
     public record TargetResponse(

--- a/src/main/java/com/example/pawgetherbe/exception/query/BookmarkQueryErrorCode.java
+++ b/src/main/java/com/example/pawgetherbe/exception/query/BookmarkQueryErrorCode.java
@@ -6,7 +6,9 @@ import org.springframework.http.HttpStatus;
 public enum BookmarkQueryErrorCode implements ErrorCode {
     NOT_FOUND_BOOKMARK(HttpStatus.NOT_FOUND, "NOT_FOUND_BOOKMARK", "북마크가 존재하지 않습니다."),
     FAIL_READ_BOOKMARK_LIST(HttpStatus.INTERNAL_SERVER_ERROR, "FAIL_READ_BOOKMARK_LIST", "북마크 리스트 불러오기 실패"),
-    FAIL_READ_BOOKMARK_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "FAIL_READ_BOOKMARK_STATUS", "북마크 상태 불러오기 실패");
+    FAIL_READ_BOOKMARK_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "FAIL_READ_BOOKMARK_STATUS", "북마크 상태 불러오기 실패"),
+    NOT_FOUND_SOME_TARGET(HttpStatus.NOT_FOUND, "NOT_FOUND_SOME_TARGET", "북마크 게시글 대상의 일부가 존재하지 않습니다."),
+    OVER_SIZE_TARGET_IDS(HttpStatus.BAD_REQUEST, "OVER_SIZE_TARGET_IDS", "요청한 게시글 아이디 개수를 확인해 주세요.");
 
     private final String message;
     private final String code;

--- a/src/main/java/com/example/pawgetherbe/mapper/query/BookmarkQueryMapper.java
+++ b/src/main/java/com/example/pawgetherbe/mapper/query/BookmarkQueryMapper.java
@@ -1,12 +1,12 @@
 package com.example.pawgetherbe.mapper.query;
 
-import com.example.pawgetherbe.controller.query.dto.BookmarkQueryDto.DetailBookmarkedPetFairResponse;
-import com.example.pawgetherbe.domain.entity.PetFairEntity;
+import com.example.pawgetherbe.controller.query.dto.BookmarkQueryDto.TargetResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper
 public interface BookmarkQueryMapper {
-    @Mapping(target="petFairId", source="entity.id")
-    DetailBookmarkedPetFairResponse toDetailBookmarkedPetPairResponse(PetFairEntity entity, boolean isBookmark);
+
+    @Mapping(target = "targetId", source = "petFairId")
+    TargetResponse toTargetResponse(long petFairId, boolean isBookmarked);
 }

--- a/src/main/java/com/example/pawgetherbe/repository/query/BookmarkQueryDSLRepository.java
+++ b/src/main/java/com/example/pawgetherbe/repository/query/BookmarkQueryDSLRepository.java
@@ -2,7 +2,6 @@ package com.example.pawgetherbe.repository.query;
 
 import com.example.pawgetherbe.controller.query.dto.BookmarkQueryDto.ReadBookmarkListResponse;
 import com.example.pawgetherbe.domain.UserContext;
-import com.example.pawgetherbe.domain.entity.BookmarkEntity;
 import com.example.pawgetherbe.domain.entity.QBookmarkEntity;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -54,6 +53,7 @@ public class BookmarkQueryDSLRepository {
 //                            bookmarkEntity.user.id.eq(Long.parseLong(UserContext.getUserId())),
                             bookmarkEntity.petFair.id.in(targetIds)
                     )
+                    .orderBy(bookmarkEntity.id.desc())
                     .fetch()
         );
     }

--- a/src/main/java/com/example/pawgetherbe/repository/query/BookmarkQueryDSLRepository.java
+++ b/src/main/java/com/example/pawgetherbe/repository/query/BookmarkQueryDSLRepository.java
@@ -1,8 +1,11 @@
 package com.example.pawgetherbe.repository.query;
 
+import com.example.pawgetherbe.controller.query.dto.BookmarkQueryDto.ReadBookmarkListResponse;
 import com.example.pawgetherbe.domain.UserContext;
 import com.example.pawgetherbe.domain.entity.BookmarkEntity;
 import com.example.pawgetherbe.domain.entity.QBookmarkEntity;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -10,6 +13,7 @@ import org.springframework.stereotype.Repository;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -18,12 +22,25 @@ public class BookmarkQueryDSLRepository {
     private final JPAQueryFactory jpaQueryFactory;
     private final QBookmarkEntity bookmarkEntity = QBookmarkEntity.bookmarkEntity;
 
-    public List<BookmarkEntity> readBookmarks() {
-        return jpaQueryFactory
-                .selectFrom(bookmarkEntity)
-                .orderBy(bookmarkEntity.createdAt.desc(), bookmarkEntity.id.desc())
+    public List<ReadBookmarkListResponse> readBookmarkList(Long lastCursor) {
+        List<Tuple> tupleList =  jpaQueryFactory
+                .select(bookmarkEntity.id, bookmarkEntity.petFair.id)
+                .from(bookmarkEntity)
+                .where(
+                        bookmarkEntity.user.id.eq(1L),
+                        // TODO: Filter에서 UserContext 사용 시 주석 코드 사용
+//                        bookmarkEntity.user.id.eq(Long.parseLong(UserContext.getUserId())),
+                        // TODO: cursor(마지막 게시글 아이디), 필터링 이상
+                        lessThenCursor(lastCursor)
+                )
+                .orderBy(bookmarkEntity.id.desc())
                 .limit(11) // hasMore 고려
                 .fetch();
+
+        return tupleList.stream()
+                .map(tuple -> new ReadBookmarkListResponse(tuple.get(bookmarkEntity.id),
+                        tuple.get(bookmarkEntity.petFair.id)))
+                .collect(Collectors.toList());
     }
 
     public Set<Long> existsBookmark(Set<Long> targetIds) {
@@ -39,5 +56,13 @@ public class BookmarkQueryDSLRepository {
                     )
                     .fetch()
         );
+    }
+
+    private BooleanExpression lessThenCursor(Long cursor) {
+        if (cursor == null) {
+            return null;
+        }
+
+        return bookmarkEntity.id.lt(cursor);
     }
 }

--- a/src/main/java/com/example/pawgetherbe/service/checker/TargetRegistry.java
+++ b/src/main/java/com/example/pawgetherbe/service/checker/TargetRegistry.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
-public class LikeTargetRegistry {
+public class TargetRegistry {
     private final Map<String, TargetChecker> checkers;
 
     public boolean existsByOneTarget(String targetType, Long targetId) {

--- a/src/main/java/com/example/pawgetherbe/service/command/BookmarkCommandService.java
+++ b/src/main/java/com/example/pawgetherbe/service/command/BookmarkCommandService.java
@@ -47,7 +47,7 @@ public class BookmarkCommandService implements RegistryBookmarkUseCase, CancelBo
             bookmarkEntity.removePetFair(petFairEntity);
             bookmarkCommandRepository.deleteByPetFair_Id(petFairId);
 
-            return new BookmarkResponse(false);
+            return new BookmarkResponse(petFairId, false);
         } catch (Exception e) {
             throw new CustomException(FAIL_CANCEL_BOOKMARK);
         }
@@ -72,7 +72,7 @@ public class BookmarkCommandService implements RegistryBookmarkUseCase, CancelBo
             bookmarkEntity.addPetFair(petFairEntity);
             bookmarkCommandRepository.save(bookmarkEntity);
 
-            return new BookmarkResponse(true);
+            return new BookmarkResponse(petFairId, true);
         } catch (Exception e) {
             throw new CustomException(FAIL_CREATE_BOOKMARK);
         }

--- a/src/main/java/com/example/pawgetherbe/service/command/LikeCommandService.java
+++ b/src/main/java/com/example/pawgetherbe/service/command/LikeCommandService.java
@@ -10,7 +10,7 @@ import com.example.pawgetherbe.mapper.command.LikeCommandMapper;
 import com.example.pawgetherbe.repository.command.LikeCommandRepository;
 import com.example.pawgetherbe.repository.query.LikeQueryDSLRepository;
 import com.example.pawgetherbe.repository.query.UserQueryRepository;
-import com.example.pawgetherbe.service.checker.LikeTargetRegistry;
+import com.example.pawgetherbe.service.checker.TargetRegistry;
 import com.example.pawgetherbe.usecase.like.CancelLikeUseCase;
 import com.example.pawgetherbe.usecase.like.LikeUseCase;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +30,7 @@ public class LikeCommandService implements LikeUseCase, CancelLikeUseCase {
 
     private final LikeCommandMapper likeCommandMapper;
 
-    private final LikeTargetRegistry likeTargetRegistry;
+    private final TargetRegistry targetRegistry;
 
     @Transactional
     @Override
@@ -44,7 +44,7 @@ public class LikeCommandService implements LikeUseCase, CancelLikeUseCase {
         );
 
         // 해당 Target 존재 유무
-        if (!likeTargetRegistry.existsByOneTarget(likeRequest.targetType(), likeRequest.targetId())) {
+        if (!targetRegistry.existsByOneTarget(likeRequest.targetType(), likeRequest.targetId())) {
             throw new CustomException(NOT_FOUND_TARGET);
         }
 

--- a/src/main/java/com/example/pawgetherbe/service/query/BookmarkQueryService.java
+++ b/src/main/java/com/example/pawgetherbe/service/query/BookmarkQueryService.java
@@ -64,6 +64,16 @@ public class BookmarkQueryService implements ReadBookmarksUseCase, IsBookmarkedU
     @Transactional(readOnly = true)
     @Override
     public Set<TargetResponse> isBookmarked(Set<Long> targetIds) {
+        // PetFair에서 10개이하로만 아이디를 제공하므로 11개 이상인 경우는 비정상적인 접근이라 판단
+        if (targetIds.size() > 10) {
+            throw new CustomException(OVER_SIZE_TARGET_IDS);
+        }
+
+        // targetIds 중에서 REMOVED || 존재하지 않는 게시글일 때 에러 반환
+        if (!targetRegistry.existsByTargetList("post", targetIds)) {
+            throw new CustomException(NOT_FOUND_SOME_TARGET);
+        }
+
         try {
             Set<Long> isBookmarkedPetFair = bookmarkQueryDSLRepository.existsBookmark(targetIds);
 

--- a/src/main/java/com/example/pawgetherbe/service/query/BookmarkQueryService.java
+++ b/src/main/java/com/example/pawgetherbe/service/query/BookmarkQueryService.java
@@ -7,6 +7,7 @@ import com.example.pawgetherbe.controller.query.dto.BookmarkQueryDto.TargetRespo
 import com.example.pawgetherbe.domain.entity.BookmarkEntity;
 import com.example.pawgetherbe.mapper.query.BookmarkQueryMapper;
 import com.example.pawgetherbe.repository.query.BookmarkQueryDSLRepository;
+import com.example.pawgetherbe.service.checker.TargetRegistry;
 import com.example.pawgetherbe.usecase.bookmark.IsBookmarkedUseCase;
 import com.example.pawgetherbe.usecase.bookmark.ReadBookmarksUseCase;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,8 @@ public class BookmarkQueryService implements ReadBookmarksUseCase, IsBookmarkedU
     private final BookmarkQueryMapper bookmarkQueryMapper;
 
     private final BookmarkQueryDSLRepository bookmarkQueryDSLRepository;
+
+    private final TargetRegistry targetRegistry;
 
     @Transactional(readOnly = true)
     public SummaryBookmarksResponse readBookmarks() {

--- a/src/main/java/com/example/pawgetherbe/service/query/LikeQueryService.java
+++ b/src/main/java/com/example/pawgetherbe/service/query/LikeQueryService.java
@@ -6,7 +6,7 @@ import com.example.pawgetherbe.domain.entity.LikeEntity;
 import com.example.pawgetherbe.exception.query.LikeQueryErrorCode;
 import com.example.pawgetherbe.mapper.query.LikeQueryMapper;
 import com.example.pawgetherbe.repository.query.LikeQueryDSLRepository;
-import com.example.pawgetherbe.service.checker.LikeTargetRegistry;
+import com.example.pawgetherbe.service.checker.TargetRegistry;
 import com.example.pawgetherbe.usecase.like.CountLikeUseCase;
 import com.example.pawgetherbe.usecase.like.ExistsLikeUseCase;
 import com.example.pawgetherbe.usecase.like.ReadLikesUseCase;
@@ -26,7 +26,7 @@ import static com.example.pawgetherbe.exception.query.LikeQueryErrorCode.NOT_FOU
 @RequiredArgsConstructor
 public class LikeQueryService implements ReadLikesUseCase, ExistsLikeUseCase, CountLikeUseCase {
 
-    private final LikeTargetRegistry likeTargetRegistry;
+    private final TargetRegistry targetRegistry;
 
     private final LikeQueryMapper likeQueryMapper;
 
@@ -99,10 +99,10 @@ public class LikeQueryService implements ReadLikesUseCase, ExistsLikeUseCase, Co
     }
 
     private boolean isExistTarget(TargetRequest targetRequest) {
-        return likeTargetRegistry.existsByOneTarget(targetRequest.targetType(), targetRequest.targetId());
+        return targetRegistry.existsByOneTarget(targetRequest.targetType(), targetRequest.targetId());
     }
 
     private boolean isExistsTargetList(TargetRequests targetRequest) {
-        return likeTargetRegistry.existsByTargetList(targetRequest.targetType(), targetRequest.targetIds());
+        return targetRegistry.existsByTargetList(targetRequest.targetType(), targetRequest.targetIds());
     }
 }

--- a/src/main/java/com/example/pawgetherbe/usecase/bookmark/ReadBookmarksUseCase.java
+++ b/src/main/java/com/example/pawgetherbe/usecase/bookmark/ReadBookmarksUseCase.java
@@ -3,5 +3,5 @@ package com.example.pawgetherbe.usecase.bookmark;
 import com.example.pawgetherbe.controller.query.dto.BookmarkQueryDto.SummaryBookmarksResponse;
 
 public interface ReadBookmarksUseCase {
-    SummaryBookmarksResponse readBookmarks();
+    SummaryBookmarksResponse readBookmarkList(Long cursor);
 }


### PR DESCRIPTION
# 개요
- 필요 로직 추가
- 에러 추가

# 작업 목록
- Like에서만 사용하던 LikeTargetRegistry를 Bookmark에서도 사용하기 위해 TargetRegistry로 변경
- 북마크 목록 조회에서 Cursor를 사용하는 로직으로 변경
- Response에 PetFair 내용 제거
- BookmarkCommandDto: targetId 필드 추가
- 변수명 통일: isBookmark -> isBookmarked
- 에러 추가
  - 마이 페이지에서 북마크 조회 시 아이디를 10개 초과해서 전달하는 경우
  - 북마크 Id 조회 시 해당 Id 없는 경우
- 정렬 순서 로직 추가

# 테스트
- api 테스트만 진행하고 단위 테스트는 별도로 진행하지 않았습니다.