### PR TITLE
fix(bookmark): add logic to handle already-bookmark

### DIFF
--- a/src/main/java/com/example/pawgetherbe/exception/command/BookmarkCommandErrorCode.java
+++ b/src/main/java/com/example/pawgetherbe/exception/command/BookmarkCommandErrorCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum BookmarkCommandErrorCode implements ErrorCode {
     NOT_FOUND_BOOKMARK(HttpStatus.NOT_FOUND, "NOT_FOUND_BOOKMARK", "북마크가 존재하지 않습니다."),
+    ALREADY_BOOKMARK(HttpStatus.CONFLICT, "ALREADY_BOOKMARK", "이미 북마크가 등록되어 있습니다."),
     FAIL_CANCEL_BOOKMARK(HttpStatus.INTERNAL_SERVER_ERROR, "FAIL_CANCEL_BOOKMARK", "북마크 취소 실패"),
     FAIL_CREATE_BOOKMARK(HttpStatus.INTERNAL_SERVER_ERROR, "FAIL_CREATE_BOOKMARK", "북마크 생성 실패");
 

--- a/src/main/java/com/example/pawgetherbe/service/command/BookmarkCommandService.java
+++ b/src/main/java/com/example/pawgetherbe/service/command/BookmarkCommandService.java
@@ -16,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static com.example.pawgetherbe.exception.command.BookmarkCommandErrorCode.*;
 import static com.example.pawgetherbe.exception.command.PetFairCommandErrorCode.NOT_FOUND_PET_FAIR;
 import static com.example.pawgetherbe.exception.command.UserCommandErrorCode.NOT_FOUND_USER;
@@ -64,6 +66,15 @@ public class BookmarkCommandService implements RegistryBookmarkUseCase, CancelBo
                 .orElseThrow(() -> new CustomException(NOT_FOUND_USER));
         PetFairEntity petFairEntity = petFairCommandRepository.findById(petFairId)
                 .orElseThrow(() -> new CustomException(NOT_FOUND_PET_FAIR));
+
+        // 해당 게시글이 이미 북마크인지 확인하는 로직 필요
+        List<BookmarkEntity> bookmarkEntityList = petFairEntity.getBookmarkEntities();
+        boolean isAlreadyExists = bookmarkEntityList.stream()
+                .anyMatch(entity -> entity.getPetFair().getId().equals(petFairId));
+
+        if (isAlreadyExists) {
+            throw new CustomException(ALREADY_BOOKMARK);
+        }
 
         BookmarkEntity bookmarkEntity = bookmarkCommandMapper.toEntity(userEntity, petFairEntity);
 


### PR DESCRIPTION
# 개요
- 추가 로직 작성

# 상세 내용
- 기존 작업: 북마크 등록 시 중복된 아이디로 등록해도 추가로 등록 + 삭제 시 2건의 동일 아이디라서 에러 발생
- 작업: 북마크 등록 시 기존에 등록되어있는지 확인하는 로직 추가

다음 작업에는 좀 더 꼼꼼히 확인하도록 하겠습니다.